### PR TITLE
ShapeFile provider performance improvement in reference with issue #12

### DIFF
--- a/SharpMap/Data/Providers/ShapeFile.cs
+++ b/SharpMap/Data/Providers/ShapeFile.cs
@@ -754,7 +754,7 @@ namespace SharpMap.Data.Providers
 
                 if (fdr == null)
                 {
-                    fdr = GetFeature(oid);
+                    fdr = getFeature(oid, dbf.NewTable, br, dbf);
                 }
 
                 return fdr.Geometry;


### PR DESCRIPTION
Prevents from instantiating a new DbaseReader unecessarily.
Allows loading shapfiles with thousands of features faster.
