### PR TITLE
Fast and accurate label collision detection method

### DIFF
--- a/SharpMap/Rendering/LabelCollisionDetection.cs
+++ b/SharpMap/Rendering/LabelCollisionDetection.cs
@@ -16,9 +16,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
 using System.Collections.Generic;
+using System.Linq;
+using System;
 
 namespace SharpMap.Rendering
-{
+{      
     /// <summary>
     /// Class defining delegate for label collision detection and static predefined methods
     /// </summary>
@@ -88,6 +90,268 @@ namespace SharpMap.Rendering
                             break;
                         }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Quick (O(n log n)) and accurate collision detection
+        /// </summary>
+        /// <param name="labels"></param>
+        public static void QuickAccurateCollisionDetectionMethod(List<BaseLabel> labels)
+	    {
+		    // find minimum / maximum coordinates
+		    double minX = double.MaxValue;
+		    double maxX = double.MinValue;
+		    double minY = double.MaxValue;
+		    double maxY = double.MinValue;
+		    foreach (BaseLabel l in labels)
+            {
+                ProperBox box = new ProperBox(l.Box);
+			    if (box.Left < minX) minX = box.Left;
+			    if (box.Right > maxX) maxX = box.Right;
+                if (box.Bottom > maxY) maxY = box.Bottom;
+			    if (box.Top < minY) minY = box.Top;
+		    }   
+
+		    // sort by area (highest priority first, followed by low area to maximize the amount of labels displayed)
+		    var sortedLabels = labels.OrderByDescending(label => label.Priority).ThenBy(label => label.Box.Width * label.Box.Height);
+
+		    // make visible if it does not collide with other labels. Uses a quadtree and is therefore fast O(n log n) 
+		    QuadtreeNode<ProperBox> quadTree = new QuadtreeNode<ProperBox>(minX, maxX, minY, maxY, new LabelBoxContainmentChecker(), 0, 10);
+		    foreach (BaseLabel l in sortedLabels) {
+			    if (!l.Show) continue;
+			    if (quadTree.CollidesWithAny(new ProperBox(l.Box)))
+                {
+				    l.Show = false;
+			    }
+                else
+                {
+				    ProperBox box = new ProperBox(l.Box);
+				    quadTree.Insert(box);
+			    }
+		    }
+	    }
+
+        #endregion
+
+        #region "Tools"
+
+        public class QuadtreeNode<T>
+        {
+            List<QuadtreeNode<T>> children = null;
+            List<T> objects;
+            int maxObjects;
+            int level;
+            int maxLevel;
+
+            public double Left { get; set; }
+            public double Right { get; set; }
+            public double Top { get; set; }
+            public double Bottom { get; set; }
+
+            protected QuadtreeContainmentChecker<T> containmentChecker;
+
+            public const int DEFAULT_MAX_OBJECTS_PER_NODE = 5;
+
+            public QuadtreeNode(double left, double right, double top, double bottom, QuadtreeContainmentChecker<T> containmentChecker, int maxObjects, int level, int maxLevel)
+            {
+                this.Left = left;
+                this.Right = right;
+                this.Top = top;
+                this.Bottom = bottom;
+                this.containmentChecker = containmentChecker;
+                this.maxObjects = maxObjects;
+                this.objects = new List<T>(maxObjects);
+                this.level = level;
+                this.maxLevel = maxLevel;
+            }
+
+            public QuadtreeNode(double left, double right, double top, double bottom, QuadtreeContainmentChecker<T> containmentChecker, int level, int maxLevel)
+                : this(left, right, top, bottom, containmentChecker, QuadtreeNode<T>.DEFAULT_MAX_OBJECTS_PER_NODE, level, maxLevel) { }
+
+            public bool Insert(T obj)
+            {
+                if (this.IsFullyContained(obj))
+                {
+                    if (this.IsLeaf())
+                    {
+                        if (objects.Count >= maxObjects && level < maxLevel)
+                        {
+                            this.Divide();
+                            if (!this.InsertIntoChildren(obj)) this.objects.Add(obj);
+                        }
+                        else
+                        {
+                            this.objects.Add(obj);
+
+                        }
+                    }
+                    else
+                    {
+                        if (!this.InsertIntoChildren(obj)) this.objects.Add(obj);
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            public bool IsFullyContained(T obj)
+            {
+                return this.containmentChecker.IsFullyContained(this, obj);
+            }
+
+            public bool CollidesWithOrContains(T obj)
+            {
+                return this.containmentChecker.IsContainedOrIntersects(this, obj);
+            }
+
+            public bool IsLeaf()
+            {
+                return this.children == null;
+            }
+
+            public List<QuadtreeNode<T>> GetChildren()
+            {
+                return this.children;
+            }
+
+            public bool CollidesWithAny(T obj)
+            {
+                if (this.CollidesWithOrContains(obj))
+                {
+                    //collides with any of current level?
+                    foreach (T o in this.objects)
+                    {
+                        if (this.containmentChecker.IsContainedOrIntersects(o, obj)) return true;
+                    }
+
+                    //collides with a child?
+                    if (!this.IsLeaf())
+                    {
+                        for (int i = 0; i < 4; i++)
+                        {
+                            if (children[i].CollidesWithAny(obj)) return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            public List<T> GetObjects(double x, double y)
+            {
+                if (this.IsLeaf())
+                {
+                    return this.objects;
+                }
+                else
+                {
+                    foreach (QuadtreeNode<T> node in this.children)
+                    {
+                        if (x >= node.Left && x <= node.Right && y >= node.Bottom && y <= node.Top)
+                        {
+                            return node.GetObjects(x, y);
+                        }
+                    }
+                }
+                return new List<T>();
+            }
+
+            protected bool InsertIntoChildren(T obj)
+            {
+                bool inserted = false;
+                for (int i = 0; i < 4; i++)
+                {
+                    if (children[i].Insert(obj)) inserted = true;
+                }
+                return inserted;
+            }
+
+            protected void Divide()
+            {
+                this.children = new List<QuadtreeNode<T>>(4);
+                double middleX = Left + ((Right - Left) / 2);
+                double middleY = Top + (Math.Abs(Top - Bottom) / 2);
+                this.children.Add(new QuadtreeNode<T>(Left, middleX, Top, middleY, containmentChecker, maxObjects, level + 1, maxLevel));
+                this.children.Add(new QuadtreeNode<T>(middleX, Right, Top, middleY, containmentChecker, maxObjects, level + 1, maxLevel));
+                this.children.Add(new QuadtreeNode<T>(Left, middleX, middleY, Bottom, containmentChecker, maxObjects, level + 1, maxLevel));
+                this.children.Add(new QuadtreeNode<T>(middleX, Right, middleY, Bottom, containmentChecker, maxObjects, level + 1, maxLevel));
+
+                //move objects to child nodes
+                List<T> remainingObjects = new List<T>();
+                foreach (T obj in this.objects)
+                {
+                    if (!this.InsertIntoChildren(obj)) remainingObjects.Add(obj);
+                }
+                this.objects = remainingObjects;
+            }
+
+            public interface QuadtreeContainmentChecker<P>
+            {
+                bool IsContainedOrIntersects(QuadtreeNode<P> node, P obj);
+
+                bool IsContainedOrIntersects(P obj1, P obj2);
+
+                bool IsFullyContained(QuadtreeNode<P> node, P obj);
+
+
+            }
+        }
+
+        public class ProperBox
+        {
+            private LabelBox box;
+            public ProperBox(LabelBox box)
+            {
+                this.box = box;
+            }
+
+            public float Left
+            {
+                get { return box.Left; }
+            }
+
+            public float Right
+            {
+                get { return box.Right; }
+            }
+
+            public float Height
+            {
+                get { return box.Height; }
+            }
+
+            public float Width
+            {
+                get { return box.Width; }
+            }
+
+            public float Bottom
+            {
+                get { return box.Top + Height; }
+            }
+
+            public float Top
+            {
+                get { return box.Top; }
+            }
+        }
+
+        public class LabelBoxContainmentChecker : QuadtreeNode<ProperBox>.QuadtreeContainmentChecker<ProperBox>
+        {
+
+            public bool IsContainedOrIntersects(QuadtreeNode<ProperBox> node, ProperBox obj)
+            {
+                return !(obj.Left > node.Right | obj.Right < node.Left | obj.Top > node.Bottom | obj.Bottom < node.Top);
+            }
+
+            public bool IsFullyContained(QuadtreeNode<ProperBox> node, ProperBox obj)
+            {
+                return obj.Left >= node.Left & obj.Right <= node.Right & obj.Bottom <= node.Bottom & obj.Top >= node.Top;
+            }
+
+            public bool IsContainedOrIntersects(ProperBox obj1, ProperBox obj2)
+            {
+                return !(obj1.Left > obj2.Right | obj1.Right < obj2.Left | obj1.Top > obj2.Bottom | obj1.Bottom < obj2.Top);
             }
         }
 


### PR DESCRIPTION
I was unsatisfied with the existing methods for label collision detection because of the following reasons:
- The fast method produces overlapping labels in complex settings
- The thorough method is slow (O(n^2)) and does sometimes produce overlapping labels. This is because the BaseLabel.Box has the Top- and Bottom values inverted:
  ![coordinatesstem](https://cloud.githubusercontent.com/assets/2946403/13742968/6978a8ce-e9df-11e5-8397-4dafd580eddc.PNG)

When rendering the label, the anchor is the top left point. In this case, that would be (left, bottom). However, (left, top) is used.

I was also unsatisfied with the slow performance of the thorough collilsion detection and therefore implemented a method that uses a quadtree for collision detection and runs in (O(n log n)) time.
