### PR TITLE
Fixed WPF example layer collection changed handler

### DIFF
--- a/SharpMap.UI.WPF/SharpMapHost.cs
+++ b/SharpMap.UI.WPF/SharpMapHost.cs
@@ -403,29 +403,33 @@ namespace SharpMap.UI.WPF
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                {
-                    var layers = sender as ObservableCollection<ILayer>;
-                    if (layers != null)
                     {
-                        foreach (var layer in layers.Where(layer => !_mapBox.Map.Layers.Contains(layer)))
+                        var layers = e.NewItems;
+                        if (layers != null)
                         {
-                            _mapBox.Map.Layers.Add(layer);
+                            foreach (var layer in layers)
+                            {
+                                var castedLayer = layer as ILayer;
+                                if (castedLayer != null && MapBox.Map.Layers.All(l => l.LayerName != castedLayer.LayerName))
+                                    MapBox.Map.Layers.Add(castedLayer);
+                            }
                         }
                     }
-                }
 
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                {
-                    var layers = sender as ObservableCollection<ILayer>;
-                    if (layers != null)
                     {
-                        foreach (var layer in layers.Where(layer => _mapBox.Map.Layers.Contains(layer)))
+                        var layers = e.OldItems;
+                        if (layers != null)
                         {
-                            _mapBox.Map.Layers.Remove(layer);
+                            foreach (var layer in layers)
+                            {
+                                var castedLayer = layer as ILayer;
+                                if (castedLayer != null && MapBox.Map.Layers.Any(l => l.LayerName == castedLayer.LayerName))
+                                    MapBox.Map.Layers.Remove(castedLayer);
+                            }
                         }
                     }
-                }
 
                     break;
                 case NotifyCollectionChangedAction.Reset:


### PR DESCRIPTION
Collection changes were not handled properly in WPF host example.

I replaces `sender` with `e.NewItems` and `e.OldItems`.

If there is existing layer with the same name as added layer, new layer is ignored.
If there is no existing layer with the same name as removed layer, noting is removed from map layers.