### PR TITLE
Fixed ToolWindow zoom when in Pan mode

### DIFF
--- a/SharpMap.UI.WPF/SharpMapHost.cs
+++ b/SharpMap.UI.WPF/SharpMapHost.cs
@@ -403,29 +403,33 @@ namespace SharpMap.UI.WPF
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                {
-                    var layers = sender as ObservableCollection<ILayer>;
-                    if (layers != null)
                     {
-                        foreach (var layer in layers.Where(layer => !_mapBox.Map.Layers.Contains(layer)))
+                        var layers = e.NewItems;
+                        if (layers != null)
                         {
-                            _mapBox.Map.Layers.Add(layer);
+                            foreach (var layer in layers)
+                            {
+                                var castedLayer = layer as ILayer;
+                                if (castedLayer != null && MapBox.Map.Layers.All(l => l.LayerName != castedLayer.LayerName))
+                                    MapBox.Map.Layers.Add(castedLayer);
+                            }
                         }
                     }
-                }
 
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                {
-                    var layers = sender as ObservableCollection<ILayer>;
-                    if (layers != null)
                     {
-                        foreach (var layer in layers.Where(layer => _mapBox.Map.Layers.Contains(layer)))
+                        var layers = e.OldItems;
+                        if (layers != null)
                         {
-                            _mapBox.Map.Layers.Remove(layer);
+                            foreach (var layer in layers)
+                            {
+                                var castedLayer = layer as ILayer;
+                                if (castedLayer != null && MapBox.Map.Layers.Any(l => l.LayerName == castedLayer.LayerName))
+                                    MapBox.Map.Layers.Remove(castedLayer);
+                            }
                         }
                     }
-                }
 
                     break;
                 case NotifyCollectionChangedAction.Reset:

--- a/SharpMap.UI/Forms/MapBox.cs
+++ b/SharpMap.UI/Forms/MapBox.cs
@@ -2256,10 +2256,17 @@ namespace SharpMap.Forms
                 {
                     if (_rectangle.Width > 0 && _rectangle.Height > 0)
                     {
+                        var zoomWindowStartPoint = _dragStartPoint;
+                        var zoomWindowEndPoint = new PointF(e.X, e.Y); 
+                    
                         Coordinate lowerLeft;
                         Coordinate upperRight;
-                        GetBounds(_map.ImageToWorld(_dragStartPoint), _map.ImageToWorld(_dragEndPoint),
-                            out lowerLeft, out upperRight);
+                        GetBounds(
+                            _map.ImageToWorld(zoomWindowStartPoint), 
+                            _map.ImageToWorld(zoomWindowEndPoint),
+                            out lowerLeft, 
+                            out upperRight);
+                            
                         _dragEndPoint.X = 0;
                         _dragEndPoint.Y = 0;
 


### PR DESCRIPTION
Fixed the issue when using ZoomWindow in Pan mode 
Issue https://github.com/SharpMap/SharpMap/issues/36

The issue is that, when the `ActiveTool` is `Pan` but we decided to apply `ToolWindow` zoom transform (because Shift modifier is active), `_dragEndPoint` was not set in `MouseMove` method (because we are in Pan mode).

To fix the problem, mouse event positions `e.X, e.Y` are used as end point (like in other tools) when mouse click is released.

**Do not merge this pull request before https://github.com/SharpMap/SharpMap/pull/40 because it contains both changes** 
(my bad, previous PR was on master branch instead of a new branch)