### PR TITLE
Extend ILayer with LayerTitle property

### DIFF
--- a/SharpMap.Web/Web/Wms/ServerCapabilities.cs
+++ b/SharpMap.Web/Web/Wms/ServerCapabilities.cs
@@ -301,7 +301,7 @@ namespace SharpMap.Web.Wms
         {
             XmlNode LayerNode = doc.CreateNode(XmlNodeType.Element, "Layer", wmsNamespaceURI);
             LayerNode.AppendChild(CreateElement("Name", layer.LayerName, doc, false, wmsNamespaceURI));
-            LayerNode.AppendChild(CreateElement("Title", layer.LayerName, doc, false, wmsNamespaceURI));
+            LayerNode.AppendChild(CreateElement("Title", layer.LayerTitle ?? layer.LayerName, doc, false, wmsNamespaceURI));
 			//if this is a vector layer with themes property set, add the Styles
             if (layer.GetType() == typeof(VectorLayer))
                 if ((layer as VectorLayer).Themes != null)

--- a/SharpMap/Layers/AsyncLayerProxyLayer.cs
+++ b/SharpMap/Layers/AsyncLayerProxyLayer.cs
@@ -124,6 +124,12 @@ namespace SharpMap.Layers
             set { _baseLayer.Enabled = value; }
         }
 
+        public string LayerTitle
+        {
+            get { return _baseLayer.LayerTitle; }
+            set { _baseLayer.LayerTitle = value; }
+        }
+
         /// <summary>
         /// Name of layer
         /// </summary>

--- a/SharpMap/Layers/GdiImageLayerProxy.cs
+++ b/SharpMap/Layers/GdiImageLayerProxy.cs
@@ -130,6 +130,12 @@ namespace SharpMap.Layers
             set { _baseLayer.Enabled = value; }
         }
 
+        public string LayerTitle
+        {
+            get { return _baseLayer.LayerTitle; }
+            set { _baseLayer.LayerTitle = value; }
+        }
+
         string ILayer.LayerName
         {
             get { return _baseLayer.LayerName; }

--- a/SharpMap/Layers/ILayer.cs
+++ b/SharpMap/Layers/ILayer.cs
@@ -52,6 +52,11 @@ namespace SharpMap.Layers
         string LayerName { get; set; }
 
         /// <summary>
+        /// Optional title of layer. It will be used for services like WMS where both Name and Title are supported.
+        /// </summary>
+        string LayerTitle { get; set; }
+
+        /// <summary>
         /// Gets the boundingbox of the entire layer
         /// </summary>
         Envelope Envelope { get; }

--- a/SharpMap/Layers/Layer.cs
+++ b/SharpMap/Layers/Layer.cs
@@ -104,6 +104,7 @@ namespace SharpMap.Layers
         private IGeometryFactory _targetFactory;
 
         private string _layerName;
+        private string _layerTitle;
         private IStyle _style;
         private int _srid = -1;
         private int? _targetSrid;
@@ -232,6 +233,15 @@ namespace SharpMap.Layers
         {
             get { return _layerName; }
             set { _layerName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the title of the layer
+        /// </summary>
+        public string LayerTitle
+        {
+            get { return _layerTitle; }
+            set { _layerTitle = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
This change extents ILayer and classes to get a new "LayerTitle" property.

It will be used for web services like WMS to correctly fill "Name" and "Title" attributes. If "Title" is not set, the previous "Name" value is used as fallback.