### PR TITLE
Issue #53: Locks, SRID, and OID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ I[V|v][V|v]*/
 I[V|v][V|v]*.*
 *I[V|v][V|v]/
 *I[V|v][V|v].*
+/SharpMap/SharpMap.png

--- a/Examples/WinFormSamples/FormMovingObjectOverTileLayer.Designer.cs
+++ b/Examples/WinFormSamples/FormMovingObjectOverTileLayer.Designer.cs
@@ -31,8 +31,8 @@
             this.components = new System.ComponentModel.Container();
             this.button4 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
-            this.mapBox1 = new SharpMap.Forms.MapBox();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.mapBox1 = new SharpMap.Forms.MapBox();
             this.SuspendLayout();
             // 
             // button4
@@ -55,13 +55,20 @@
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
+            // timer1
+            // 
+            this.timer1.Interval = 50;
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            // 
             // mapBox1
             // 
             this.mapBox1.ActiveTool = SharpMap.Forms.MapBox.Tools.Pan;
             this.mapBox1.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.mapBox1.CustomTool = null;
             this.mapBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.mapBox1.FineZoomFactor = 10D;
             this.mapBox1.Location = new System.Drawing.Point(0, 0);
+            this.mapBox1.MapQueryMode = SharpMap.Forms.MapBox.MapQueryType.LayerByIndex;
             this.mapBox1.Name = "mapBox1";
             this.mapBox1.PreviewMode = SharpMap.Forms.MapBox.PreviewModes.Fast;
             this.mapBox1.QueryGrowFactor = 5F;
@@ -73,11 +80,6 @@
             this.mapBox1.TabIndex = 2;
             this.mapBox1.Text = "mapBox1";
             this.mapBox1.WheelZoomMagnitude = 2D;
-            // 
-            // timer1
-            // 
-            this.timer1.Interval = 20;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
             // FormMovingObjectOverTileLayer
             // 

--- a/Examples/WinFormSamples/FormMovingObjectOverTileLayer.cs
+++ b/Examples/WinFormSamples/FormMovingObjectOverTileLayer.cs
@@ -23,7 +23,7 @@ namespace WinFormSamples
 
         public FormMovingObjectOverTileLayer()
         {
-   
+
             InitializeComponent();
             this.SetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint, true);
             this.UpdateStyles();
@@ -55,7 +55,7 @@ namespace WinFormSamples
             staticLayer.DataSource = geoProviderFixed;
             this.mapBox1.Map.Layers.Add(staticLayer);
 
-            
+
             //Adds a moving variable layer
             VectorLayer pushPinLayer = new VectorLayer("PushPins");
             position = geom.Centre;
@@ -96,8 +96,9 @@ namespace WinFormSamples
             else if (position.Y > this.mapBox1.Map.Envelope.MaxY)
                 movingUp = false;
 
-            VariableLayerCollection.TouchTimer();
-            //this.mapBox1.Refresh();
+            //static method replaced by instance method
+            //VariableLayerCollection.TouchTimer();
+            this.mapBox1.Map.VariableLayers.TouchTimer();
 
         }
 

--- a/Examples/WinFormSamples/Samples/ShapefileSampleOsm.cs
+++ b/Examples/WinFormSamples/Samples/ShapefileSampleOsm.cs
@@ -334,7 +334,7 @@ namespace WinFormSamples.Samples
             bmp.MakeTransparent(bmp.GetPixel(0, 0));
             vl.Style.Symbol = bmp;
 
-            VariableLayerCollection.Interval = 500;
+            map.VariableLayers.Interval = 500;
             map.VariableLayers.Add(vl);
 
             //Restrict zoom

--- a/Examples/WinFormSamples/Samples/TileLayerSample.cs
+++ b/Examples/WinFormSamples/Samples/TileLayerSample.cs
@@ -149,7 +149,7 @@ namespace WinFormSamples.Samples
             vl.Theme = new SharpMap.Rendering.Thematics.CustomTheme(pttTrolley.GetStyle);
             vl.CoordinateTransformation = GetCoordinateTransformation();
             map.VariableLayers.Add(vl);
-            SharpMap.Layers.VariableLayerCollection.Interval = 5000;
+            map.VariableLayers.Interval = 5000;
 
             map.ZoomToBox(vl.Envelope);
 

--- a/SharpMap.UI/Forms/MapBox.cs
+++ b/SharpMap.UI/Forms/MapBox.cs
@@ -770,7 +770,7 @@ namespace SharpMap.Forms
                 ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.UserPaint, true);
             base.DoubleBuffered = true;
             _map = new Map(ClientSize);
-            VariableLayerCollection.VariableLayerCollectionRequery += HandleVariableLayersRequery;
+            _map.VariableLayers.VariableLayerCollectionRequery += HandleVariableLayersRequery;
             _map.RefreshNeeded += HandleRefreshNeeded;
             _map.MapNewTileAvaliable += HandleMapNewTileAvaliable;
 
@@ -816,9 +816,12 @@ namespace SharpMap.Forms
             if (_isDisposed || IsDisposed)
                 return;
 
-            VariableLayerCollection.VariableLayerCollectionRequery -= HandleVariableLayersRequery;
+            
             if (_map != null)
             {
+                // special handling to prevent spurious VariableLayers events
+                _map.VariableLayers.Interval = 0;
+                _map.VariableLayers.VariableLayerCollectionRequery -= HandleVariableLayersRequery;
                 _map.MapNewTileAvaliable -= HandleMapNewTileAvaliable;
                 _map.RefreshNeeded -= HandleRefreshNeeded;
             }
@@ -1735,7 +1738,7 @@ namespace SharpMap.Forms
 
             if (_map != null)
             {
-                VariableLayerCollection.VariableLayerCollectionRequery -= HandleVariableLayersRequery;
+                _map.VariableLayers.VariableLayerCollectionRequery -= HandleVariableLayersRequery;
                 _map.MapNewTileAvaliable -= HandleMapNewTileAvaliable;
                 _map.RefreshNeeded -= HandleRefreshNeeded;
             }
@@ -1749,7 +1752,7 @@ namespace SharpMap.Forms
         {
             if (_map != null)
             {
-                VariableLayerCollection.VariableLayerCollectionRequery += HandleVariableLayersRequery;
+                _map.VariableLayers.VariableLayerCollectionRequery += HandleVariableLayersRequery;
                 _map.MapNewTileAvaliable += HandleMapNewTileAvaliable;
                 _map.RefreshNeeded += HandleRefreshNeeded;
                 Refresh();

--- a/SharpMap.UI/Forms/MapImage.cs
+++ b/SharpMap.UI/Forms/MapImage.cs
@@ -107,12 +107,24 @@ namespace SharpMap.Forms
             base.MouseDown += new System.Windows.Forms.MouseEventHandler(MapImage_MouseDown);
             base.MouseWheel += new System.Windows.Forms.MouseEventHandler(MapImage_Wheel);
             base.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(MapImage_DblClick);
-            VariableLayerCollection.VariableLayerCollectionRequery += this.VariableLayersRequery;
+            _map.VariableLayers.VariableLayerCollectionRequery += this.VariableLayersRequery;
             Cursor = Cursors.Cross;
             DoubleBuffered = true;
         }
 
-        protected override void Dispose(bool disposing)        {            VariableLayerCollection.VariableLayerCollectionRequery -= this.VariableLayersRequery;            base.Dispose(disposing);        }        [Description("The amount which a single movement of the mouse wheel zooms by.")]
+        protected override void Dispose(bool disposing)
+        {
+            if (_map != null)
+            {
+                // special handling to prevent spurious VariableLayers events
+                _map.VariableLayers.Interval = 0;
+                _map.VariableLayers.VariableLayerCollectionRequery -= this.VariableLayersRequery;
+            }
+            
+            base.Dispose(disposing);
+        }
+
+        [Description("The amount which a single movement of the mouse wheel zooms by.")]
         [DefaultValue(-2)]
         [Category("Behavior")]
         public double WheelZoomMagnitude
@@ -156,7 +168,7 @@ namespace SharpMap.Forms
                 _map = value;
                 if (_map != null)
                 {
-                    VariableLayerCollection.VariableLayerCollectionRequery += new VariableLayerCollectionRequeryHandler(VariableLayersRequery);
+                    _map.VariableLayers.VariableLayerCollectionRequery += new VariableLayerCollectionRequeryHandler(VariableLayersRequery);
                     Refresh();
                 }
             }

--- a/SharpMap.UI/Forms/ToolBar/MapVariableLayerToolStrip.cs
+++ b/SharpMap.UI/Forms/ToolBar/MapVariableLayerToolStrip.cs
@@ -14,7 +14,7 @@ namespace SharpMap.Forms.ToolBar
         private System.Timers.Timer _timer;
 
         public MapVariableLayerToolStrip()
-            :base()
+            : base()
         {
             InitializeComponent();
         }
@@ -74,7 +74,7 @@ namespace SharpMap.Forms.ToolBar
         private void OnTextChanged(object sender, EventArgs e)
         {
             int val;
-            if (int.TryParse(_interval.Text, System.Globalization.NumberStyles.Integer, 
+            if (int.TryParse(_interval.Text, System.Globalization.NumberStyles.Integer,
                 System.Globalization.NumberFormatInfo.InvariantInfo, out val))
             {
                 if (val < 500) val = 500;
@@ -103,7 +103,8 @@ namespace SharpMap.Forms.ToolBar
         {
             if (Logger.IsDebugEnabled)
                 Logger.DebugFormat("Touching timer at {0}", e.SignalTime);
-            SharpMap.Layers.VariableLayerCollection.TouchTimer();
+
+            base.MapControl.Map.VariableLayers.TouchTimer();
         }
     }
 }

--- a/SharpMap/Data/Providers/DbaseReader.cs
+++ b/SharpMap/Data/Providers/DbaseReader.cs
@@ -765,8 +765,11 @@ namespace SharpMap.Data.Providers
         {
             _baseTable = new FeatureDataTable();
             if (IncludeOid)
+            {
                 _baseTable.Columns.Add("Oid", typeof(UInt32));
-
+                _baseTable.PrimaryKey = new DataColumn[] { _baseTable.Columns[0] };
+            }
+              
             foreach (var dbf in _dbaseColumns)
             {
                 //_baseTable.Columns.Add(dbf.ColumnName, dbf.DataType);

--- a/SharpMap/Data/Providers/GeometryFeatureProvider.cs
+++ b/SharpMap/Data/Providers/GeometryFeatureProvider.cs
@@ -227,7 +227,7 @@ namespace SharpMap.Data.Providers
                             if (_oid == -1)
                                 yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
                             else
-                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)feature[_oid], feature);
+                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)(int)feature[_oid], feature);
                         }
                         id++;
                     }
@@ -241,7 +241,7 @@ namespace SharpMap.Data.Providers
                             if (_oid == -1)
                                 yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
                             else
-                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)feature[_oid], feature);
+                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)(int)feature[_oid], feature);
                         }
                         id++;
                     }
@@ -277,7 +277,7 @@ namespace SharpMap.Data.Providers
                 else
                 {
                     DataRow dr;
-                    dr = _features.Rows.Find(_oid);
+                    dr = _features.Rows.Find(oid);
                     if (dr != null)
                         return ((FeatureDataRow)dr).Geometry;
                     else

--- a/SharpMap/Data/Providers/GeometryFeatureProvider.cs
+++ b/SharpMap/Data/Providers/GeometryFeatureProvider.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
 using GeoAPI.Geometries;
+using System.ComponentModel;
 
 namespace SharpMap.Data.Providers
 {
@@ -59,9 +60,9 @@ namespace SharpMap.Data.Providers
     /// </remarks>
     public class GeometryFeatureProvider : FilterProvider, IProvider
     {
-        private readonly object _featuresLock = new object();
         private readonly FeatureDataTable _features;
         private int _srid = -1;
+        private int _oid = -1; // primary key index from fdt schema or subsequently added unique constraint
 
         #region constructors
 
@@ -72,13 +73,21 @@ namespace SharpMap.Data.Providers
         public GeometryFeatureProvider(IEnumerable<IGeometry> geometries)
         {
             _features = new FeatureDataTable();
+            _features.BeginLoadData();
             foreach (var geom in geometries)
             {
                 var fdr = _features.NewRow();
                 fdr.Geometry = geom;
                 _features.AddRow(fdr);
             }
+            _features.AcceptChanges();
+            _features.EndLoadData();
+
             _features.TableCleared += HandleFeaturesCleared;
+            _features.Constraints.CollectionChanged += HandleConstraintsCollectionChanged;
+
+            if (_features.Count > 0 && _features[0].Geometry != null)
+                SRID = _features[0].Geometry.SRID;
         }
 
         /// <summary>
@@ -89,6 +98,15 @@ namespace SharpMap.Data.Providers
         {
             _features = features;
             _features.TableCleared += HandleFeaturesCleared;
+            _features.Constraints.CollectionChanged += HandleConstraintsCollectionChanged;
+
+            if (_features != null && _features.Count > 0)
+                if (_features[0].Geometry != null)
+                    SRID = _features[0].Geometry.SRID;
+
+            // eg ShapeFile datasource with IncludeOid = true
+            if (features.PrimaryKey.Length == 1)
+                _oid = ValidateOidDataType(features.PrimaryKey[0]);
         }
 
         /// <summary>
@@ -100,16 +118,60 @@ namespace SharpMap.Data.Providers
             _features = new FeatureDataTable();
             var fdr = _features.NewRow();
             fdr.Geometry = geometry;
+            if (geometry != null)
+                SRID = geometry.SRID;
             _features.AddRow(fdr);
+            _features.AcceptChanges();
+
             _features.TableCleared += HandleFeaturesCleared;
+            _features.Constraints.CollectionChanged += HandleConstraintsCollectionChanged;
         }
 
         #endregion
 
         private void HandleFeaturesCleared(object sender, DataTableClearEventArgs e)
         {
-            //maybe clear extents
+            //maybe clear extents, reset SRID
             //ok, maybe not
+        }
+
+        private void HandleConstraintsCollectionChanged(object sender, CollectionChangeEventArgs e)
+        {
+            // rare cases when PK is explicitly added/removed subsequent to constructor
+            if (e.Element is UniqueConstraint)
+            {
+                UniqueConstraint uc;
+                uc = (UniqueConstraint)e.Element;
+                // Ensure we are dealing with PK....
+                // IsPrimaryKey only True for REMOVE or REFRESH. When ADDing new PK constraint 
+                // IsPrimaryKey is False until after constraint applied, so for this case confirm 
+                // no existing PK and check constraint for single col, !AllowDBNull and Unique
+                if ((uc.IsPrimaryKey && _features.PrimaryKey.Length == 1) ||
+                    (_features.PrimaryKey.Length == 0 && uc.Columns.Length == 1 &&
+                    !uc.Columns[0].AllowDBNull && uc.Columns[0].Unique))
+                {
+                    if (e.Action == CollectionChangeAction.Remove)
+                        _oid = -1;
+                    else
+                        _oid = ValidateOidDataType(uc.Columns[0]);
+                }
+            }
+        }
+
+        private int ValidateOidDataType(DataColumn pk)
+        {
+            switch (Type.GetTypeCode(pk.DataType))
+            {
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                    return pk.Ordinal;
+                default:
+                    return -1;
+            }
         }
 
         /// <summary>
@@ -119,7 +181,7 @@ namespace SharpMap.Data.Providers
         {
             get
             {
-                lock (_features)
+                lock (_features.Rows.SyncRoot)
                 {
                     return _features;
                 }
@@ -137,7 +199,7 @@ namespace SharpMap.Data.Providers
         {
             var list = new Collection<IGeometry>();
 
-            lock (_features)
+            lock (_features.Rows.SyncRoot)
             {
                 foreach (FeatureDataRow fdr in _features.Rows)
                     if (!fdr.Geometry.IsEmpty)
@@ -152,7 +214,7 @@ namespace SharpMap.Data.Providers
 
         private IEnumerable<KeyValuePair<uint, FeatureDataRow>> EnumerateFeatures(Envelope bbox)
         {
-            lock (_featuresLock)
+            lock (_features.Rows.SyncRoot)
             {
                 uint id = 0;
                 if (FilterDelegate == null)
@@ -161,7 +223,12 @@ namespace SharpMap.Data.Providers
                         var geom = feature.Geometry;
                         var testBox = geom != null ? geom.EnvelopeInternal : new Envelope(bbox);
                         if (bbox.Intersects(testBox))
-                            yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
+                        {
+                            if (_oid == -1)
+                                yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
+                            else
+                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)feature[_oid], feature);
+                        }
                         id++;
                     }
                 else
@@ -170,7 +237,12 @@ namespace SharpMap.Data.Providers
                         var geom = feature.Geometry;
                         var testBox = geom != null ? geom.EnvelopeInternal : new Envelope(bbox);
                         if (bbox.Intersects(testBox) && FilterDelegate(feature))
-                            yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
+                        {
+                            if (_oid == -1)
+                                yield return new KeyValuePair<uint, FeatureDataRow>(id, feature);
+                            else
+                                yield return new KeyValuePair<uint, FeatureDataRow>((uint)feature[_oid], feature);
+                        }
                         id++;
                     }
             }
@@ -198,21 +270,32 @@ namespace SharpMap.Data.Providers
         /// <returns>geometry</returns>
         public IGeometry GetGeometryByID(uint oid)
         {
-            lock (_featuresLock)
+            lock (_features.Rows.SyncRoot)
             {
-                return ((FeatureDataRow)_features.Rows[(int)oid]).Geometry;
+                if (_oid == -1)
+                    return ((FeatureDataRow)_features.Rows[(int)oid]).Geometry;
+                else
+                {
+                    DataRow dr;
+                    dr = _features.Rows.Find(_oid);
+                    if (dr != null)
+                        return ((FeatureDataRow)dr).Geometry;
+                    else
+                        return null;
+                }
+
             }
         }
 
         /// <summary>
-        /// Throws an NotSupportedException. Attribute data is not supported by this datasource
+        /// Add datatable to dataset and populate with intersecting features (perform bounding box intersect followed by geom intersect)
         /// </summary>
         /// <param name="geom"></param>
         /// <param name="ds">FeatureDataSet to fill data into</param>
         public void ExecuteIntersectionQuery(IGeometry geom, FeatureDataSet ds)
         {
             FeatureDataTable fdt;
-            lock (_featuresLock)
+            lock (_features.Columns.SyncRoot)
                 fdt = _features.Clone();
 
             fdt.BeginLoadData();
@@ -234,14 +317,14 @@ namespace SharpMap.Data.Providers
         }
 
         /// <summary>
-        /// Throws an NotSupportedException. Attribute data is not supported by this datasource
+        /// Add datatable to dataset and populate with interesecting features
         /// </summary>
         /// <param name="box"></param>
         /// <param name="ds">FeatureDataSet to fill data into</param>
         public void ExecuteIntersectionQuery(Envelope box, FeatureDataSet ds)
         {
             FeatureDataTable fdt;
-            lock (_featuresLock)
+            lock (_features.Columns.SyncRoot)
                 fdt = _features.Clone();
 
             fdt.BeginLoadData();
@@ -249,10 +332,11 @@ namespace SharpMap.Data.Providers
             {
                 var fdr = idFeature.Value;
                 fdt.LoadDataRow(fdr.ItemArray, false);
-                var geom =  fdr.Geometry;
+                var geom = fdr.Geometry;
                 if (geom != null)
                     ((FeatureDataRow)fdt.Rows[fdt.Rows.Count - 1]).Geometry = (IGeometry)geom.Clone();
             }
+            fdt.AcceptChanges();
             fdt.EndLoadData();
 
             ds.Tables.Add(fdt);
@@ -264,7 +348,7 @@ namespace SharpMap.Data.Providers
         /// <returns>number of features</returns>
         public int GetFeatureCount()
         {
-            lock(_featuresLock)
+            lock (_features.Rows.SyncRoot)
                 return _features.Rows.Count;
         }
 
@@ -275,7 +359,7 @@ namespace SharpMap.Data.Providers
         /// <returns>A feature data row</returns>
         public FeatureDataRow GetFeature(uint rowId)
         {
-            lock (_featuresLock)
+            lock (_features.Rows.SyncRoot)
             {
                 if (rowId >= _features.Rows.Count)
                 {
@@ -300,10 +384,11 @@ namespace SharpMap.Data.Providers
         /// <returns>boundingbox</returns>
         public Envelope GetExtents()
         {
-            lock (_featuresLock)
+            lock (_features.Rows.SyncRoot)
             {
                 if (_features.Rows.Count == 0)
                     return null;
+
                 var box = new Envelope();
 
                 foreach (FeatureDataRow fdr in _features.Rows)
@@ -365,6 +450,9 @@ namespace SharpMap.Data.Providers
         /// </summary>
         public void Dispose()
         {
+            _features.TableCleared -= HandleFeaturesCleared;
+            _features.Constraints.CollectionChanged -= HandleConstraintsCollectionChanged;
+
             _features.Dispose();
         }
 

--- a/SharpMap/Map/Map.cs
+++ b/SharpMap/Map/Map.cs
@@ -597,7 +597,7 @@ namespace SharpMap
                 throw new ArgumentNullException("g", "Cannot render map with null graphics object!");
 
             //Pauses the timer for VariableLayer
-            VariableLayerCollection.Pause = true;
+            _variableLayers.Pause = true;
 
             if ((Layers == null || Layers.Count == 0) && (BackgroundLayer == null || BackgroundLayer.Count == 0) && (_variableLayers == null || _variableLayers.Count == 0))
                 throw new InvalidOperationException("No layers to render");
@@ -685,7 +685,7 @@ namespace SharpMap
                 mapDecoration.Render(g, this);
             }
             //Resets the timer for VariableLayer
-            VariableLayerCollection.Pause = false;
+            _variableLayers.Pause = false;
 
             OnMapRendered(g);
         }
@@ -783,7 +783,7 @@ namespace SharpMap
             if (g == null)
                 throw new ArgumentNullException("g", "Cannot render map with null graphics object!");
 
-            VariableLayerCollection.Pause = true;
+            _variableLayers.Pause = true;
 
             LayerCollection lc = null;
             switch (layerCollectionType)
@@ -850,7 +850,7 @@ namespace SharpMap
 
 
 
-            VariableLayerCollection.Pause = false;
+            _variableLayers.Pause = false;
 
         }
 


### PR DESCRIPTION
Addressing [Issue 53](https://github.com/SharpMap/SharpMap/issues/53):

Updates for GeometryProvider, GeometryFeatureProvider, and VectorLayer included in 1st commit (2e84c20):

1) consistent use of LOCK in GeometryProvider, GeometryFeatureProvider, and VectorLayer
2) set SRID in GeometryFeatureProvider constructors (as per GeometryProvider)
3) DbaseReader define PrimaryKey when IncludeOid = true
4) add support for Oid in GeometryFeatureProvider to preserve Oid after selecting from ShapeFile dataprovider. Other DataProviders (eg MsSql) to be reviewed on case-by-case basis.

And updates for VariableLayerCollection have been included in 2nd commit (80a19b8):
1) replace static members/methods (previously used to avoid race condition) with intance members/methods
2) bug fix for double refreshes
3) handle potential race condition (lightweight approach.... if this isn't acceptable I can implement Dispose on VariableLayerCollection).