### PR TITLE
Scale bar tidy up

### DIFF
--- a/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
+++ b/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
@@ -69,9 +69,8 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         public ScaleBar()
         {
             MapUnit = (int)Unit.Meter;
-            // set bigger unit first
-            BarUnitSmallScale = (int)Unit.Kilometer;
             BarUnitLargeScale = (int)Unit.Meter;
+            BarUnitSmallScale = (int)Unit.Kilometer;
             Scale = 1;
             Width = DefaultWidth;
         }
@@ -721,9 +720,8 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                         case Unit.Kilometer:
                         case Unit.Nautical_Mile:
                             {
-                                // set bigger unit of measure first
-                                BarUnitSmallScale = (int)Unit.Kilometer;
                                 BarUnitLargeScale = (int)Unit.Meter;
+                                BarUnitSmallScale = (int)Unit.Kilometer;
                                 return;
                             }
 
@@ -731,40 +729,37 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                         case Unit.Yard_Indian:
                         case Unit.Yard_Sears:
                             {
-                                // set bigger unit of measure first
-                                BarUnitSmallScale = (int)Unit.Mile_US;
                                 BarUnitLargeScale = value;
+                                BarUnitSmallScale = (int)Unit.Mile_US;
                                 return;
                             }
 
                         case Unit.Mile_US:
                             {
-                                // set bigger unit of measure first
-                                BarUnitSmallScale = (int)Unit.Mile_US;
                                 BarUnitLargeScale = (int)Unit.Yard_Sears;
+                                BarUnitSmallScale = (int)Unit.Mile_US;
                                 return;
                             }
 
                         case Unit.Degree:
                             {
-                                // set bigger unit of measure first
-                                BarUnitSmallScale = (int)Unit.Degree;
                                 BarUnitLargeScale = (int)Unit.Degree;
+                                BarUnitSmallScale = (int)Unit.Degree;
                                 return;
                             }
 
                         default:
                             {
-                                BarUnitSmallScale = (int)Unit.Custom;
                                 BarUnitLargeScale = (int)Unit.Custom;
+                                BarUnitSmallScale = (int)Unit.Custom;
                                 return;
                             }
                     }
                 }
                 else
                 {
-                    BarUnitSmallScale = (int)Unit.Custom;
                     BarUnitLargeScale = (int)Unit.Custom;
+                    BarUnitSmallScale = (int)Unit.Custom;
                     return;
                 }
             }
@@ -779,9 +774,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             set
             {
                 GetUnitInformation(value, out double d, out _barUnitNameLargeScale, out _barUnitShortNameLargeScale);
-
-                if (d > _barUnitFactorSmallScale) //d > 1 && value != (int)Unit.Degree
-                    throw new ArgumentOutOfRangeException("typically ft, m, or yd (unit of measure must be <= unit specified for BarUnitSmallScale");
 
                 _barUnitLargeScale = value;
                 _barUnitFactorLargeScale = d;
@@ -801,9 +793,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             set
             {
                 GetUnitInformation(value, out double d, out _barUnitNameSmallScale, out _barUnitShortNameSmallScale);
-
-                if (d < _barUnitFactorLargeScale) //d < 1 && 
-                    throw new ArgumentOutOfRangeException("typically km, mi, nm, or deg (unit of measure must be >= unit specified for BarUnitLargeScale");
 
                 _barUnitSmallScale = value;
                 _barUnitFactorSmallScale = d;

--- a/SharpMap/Utilities/GeoSpatialMath.cs
+++ b/SharpMap/Utilities/GeoSpatialMath.cs
@@ -50,7 +50,7 @@ namespace SharpMap.Utilities
         }
 
         /// <summary>
-        /// Calculate the distance between 2 points on the great circle
+        /// Calculate the great circle distance between 2 points (ie the shortest distance on the sphere)
         /// </summary>
         /// <param name="lon1">The first longitue value</param>
         /// <param name="lon2">The second longitue value</param>
@@ -58,7 +58,7 @@ namespace SharpMap.Utilities
         /// <returns>The distance in meters</returns>
         public static double GreatCircleDistance(double lon1, double lon2, double lat)
         {
-            var lonDistance = Math.Abs(lon2 - lon1);//DiffLongitude(lon1, lon2);
+            var lonDistance = DiffLongitude(lon1, lon2);
             lat = Math.Abs(lat);
             if (lat >= 90.0)
                 lat = 89.999;
@@ -67,7 +67,27 @@ namespace SharpMap.Utilities
         }
 
         /// <summary>
-        /// Calculate the difference between two longitudal values
+        /// Calculate the great circle distance between 2 points without constraining longitudinal REFLEX angle 0-180deg (ie supports angles > 180 deg).
+        /// Typically used to support scale calculations on a global projection from longitude -180 to +180 (or even greater when zoomed out), 
+        /// this will NOT be the shortest distance on the sphere when longitudinal angle > 180 degrees.
+        /// </summary>
+        /// <param name="lon1">The first longitude value</param>
+        /// <param name="lon2">The second longitude value</param>
+        /// <param name="lat">The common latitude value for <paramref name="lon1"/> and <paramref name="lon2"/></param>
+        /// <returns>The distance in meters from LHS to RHS of a global projection. 
+        /// This will NOT the shortest distance on sphere for longitudinal REFLEX (> 180deg) angles</returns>
+        public static double GreatCircleDistanceReflex(double lon1, double lon2, double lat)
+        {
+            var lonDistance = Math.Abs(lon2 - lon1);
+            lat = Math.Abs(lat);
+            if (lat >= 90.0)
+                lat = 89.999;
+            var distance = Math.Cos(lat * DegToRad) * MetersPerDegreeAtEquator * lonDistance;
+            return distance;
+        }
+
+        /// <summary>
+        /// Calculate the difference between two longitudal values constrained 0 - 180 deg
         /// </summary>
         /// <param name="lon1">The first longitue value in degrees</param>
         /// <param name="lon2">The second longitue value in degrees</param>

--- a/SharpMap/Utilities/ScaleCalculations.cs
+++ b/SharpMap/Utilities/ScaleCalculations.cs
@@ -74,7 +74,7 @@ namespace SharpMap.Utilities
         /// <returns></returns>
         public static double CalculateScaleLatLong(double lon1, double lon2, double lat, double widthPage, int dpi)
         {
-            double distance = GeoSpatialMath.GreatCircleDistance(lon1, lon2, lat);
+            double distance = GeoSpatialMath.GreatCircleDistanceReflex(lon1, lon2, lat);
             double r = CalculateScaleNonLatLong(distance, widthPage, 1, dpi);
             return r;
         }


### PR DESCRIPTION
1. Remove [ArgumentOutOfRangeExceptions ](https://github.com/SharpMap/SharpMap/commit/be22e274cbca51f672888239468c8f858d215743#diff-6ccd96624c94c0fca6a8a548d06e1d63L783) when setting BarUnitLargeScale and BarUnitSmallScale (and hence removes need to set BarUnitSmallScale first)<br/>
2. Revert changes to static func [GeoSpatialMath.GreatCircleDistance](https://github.com/SharpMap/SharpMap/commit/be22e274cbca51f672888239468c8f858d215743#diff-5af6430a8a33d2ab8927bb0a6fb18afeR61) in case this is being used outside of SharpMap assemblies. For example, if longitude 1 = -170deg and longitude 2 = +170deg, GreatCircleDistance returns for distance based upon 20 deg.  <br/>
3. Add new static func GeoSpatialMath.[GreatCircleDistanceReflex ](https://github.com/SharpMap/SharpMap/commit/be22e274cbca51f672888239468c8f858d215743#diff-5af6430a8a33d2ab8927bb0a6fb18afeR79) for scale bar calcs that preserves longitudinal Reflex angles (ie angles > 180 deg). For example, if LHS map = -170deg and RHS map = +170deg, GreatCircleDistanceReflex returns distance based upon 340deg. 