### PR TITLE
MapTransform enhancements in Map, MapViewport, and MapDecoration

### DIFF
--- a/SharpMap.UI/Forms/ToolBar/MapZoomToolStrip.cs
+++ b/SharpMap.UI/Forms/ToolBar/MapZoomToolStrip.cs
@@ -451,16 +451,14 @@ namespace SharpMap.Forms.ToolBar
             
             if (tsb == _minZoom)
             {
-                MapControl.Map.MinimumZoom = _minZoom.Checked
-                    ? MapControl.Map.MinimumZoom = MapControl.Map.Zoom
-                    : MapControl.Map.MinimumZoom = Double.Epsilon;
+                MapControl.Map.MinimumZoom =
+                    _minZoom.Checked ? MapControl.Map.Zoom : Double.Epsilon;
             }
             
             if (tsb == _maxZoom)
             {
-                MapControl.Map.MaximumZoom = _maxZoom.Checked
-                    ? MapControl.Map.MaximumZoom = MapControl.Map.Zoom
-                    : MapControl.Map.MaximumZoom = Double.MaxValue;
+                MapControl.Map.MaximumZoom =
+                    _maxZoom.Checked ? MapControl.Map.Zoom : Double.MaxValue;
             }
 
             if (tsb == _lock)
@@ -481,6 +479,23 @@ namespace SharpMap.Forms.ToolBar
 
         private MapViewportLock mvpLock;
 
+        private void ResetControls()
+        {
+            Visible = true;
+            
+            if (MapControl.Map != null)
+            {
+                _minZoom.Checked = MapControl.Map.MinimumZoom > Double.Epsilon;
+                _maxZoom.Checked = MapControl.Map.MaximumZoom < Double.MaxValue;
+                _maxZoom2.Checked = MapControl.Map.MaximumExtents != null;
+            }
+
+            _zoomExtentStack = new ZoomExtentStack(MapControl);
+            _zoomExtentStack.StoreExtents = true;
+
+            mvpLock = new MapViewportLock(MapControl.Map);
+        }
+        
         protected override void OnMapControlChangedInternal(EventArgs e)
         {
             if (MapControl == null)
@@ -505,18 +520,9 @@ namespace SharpMap.Forms.ToolBar
                                                 /*_predefinedScales.Enabled =*/
                                                 MapControl.Map != null;
 
-            if (MapControl.Map != null)
-            {
-                _minZoom.Checked = MapControl.Map.MinimumZoom > Double.Epsilon;
-                _maxZoom.Checked = MapControl.Map.MaximumZoom < Double.MaxValue;
-                _maxZoom2.Checked = MapControl.Map.MaximumExtents != null;
-            }
-
             Visible = true;
-            _zoomExtentStack = new ZoomExtentStack(MapControl);
-            _zoomExtentStack.StoreExtents = true;
 
-            mvpLock = new MapViewportLock(MapControl.Map);
+            ResetControls();
 
             MapControl.Visible = true;
         }
@@ -526,13 +532,12 @@ namespace SharpMap.Forms.ToolBar
             if (sender != MapControl)
                 return;
 
-            _zoomExtentStack = new ZoomExtentStack(MapControl);
-            _zoomExtentStack.StoreExtents = true;
-
+            ResetControls();
+           
             _predefinedScales.Text = string.Format(NumberFormatInfo.CurrentInfo, "1:{0}", 
                 Math.Round(MapControl.Map.GetMapScale(_dpiX), 0, MidpointRounding.AwayFromZero));
+
             MapControl.Map.MapViewOnChange += OnMapMapViewOnChange;
-            mvpLock = new MapViewportLock(MapControl.Map);
         }
 
         private void HandleMapChanging(object sender, CancelEventArgs e)

--- a/SharpMap/Geometries/GeoAPIEx.cs
+++ b/SharpMap/Geometries/GeoAPIEx.cs
@@ -6,6 +6,7 @@ using System.Drawing.Drawing2D;
 using System.Reflection;
 using NetTopologySuite.Geometries;
 using SharpMap.Rendering;
+using SharpMap.Utilities;
 
 namespace GeoAPI.Geometries
 {
@@ -264,25 +265,14 @@ namespace GeoAPI.Geometries
         /// Transforms a <see cref="ILineString"/> to an array of <see cref="PointF"/>s.
         /// </summary>
         /// <param name="self">The linestring</param>
-        /// <param name="map">The map that defines the affine coordinate transformation</param>
+        /// <param name="map">The mapviewport defining transformation parameters</param>
         /// <returns>The array of <see cref="PointF"/>s</returns>
         public static PointF[] TransformToImage(this ILineString self, MapViewport map)
         {
-            return TransformToImage(self.Coordinates, map);
-        }
+            if (map.MapTransformRotation.Equals(0f))
+                return Transform.WorldToMap(self.Coordinates, map.Left, map.Top, map.PixelWidth, map.PixelHeight);
 
-        /// <summary>
-        /// Transforms an array of <see cref="Coordinate"/>s to an array of <see cref="PointF"/>s.
-        /// </summary>
-        /// <param name="vertices">The array of coordinates</param>
-        /// <param name="map">The map that defines the affine coordinate transformation</param>
-        /// <returns>The array of <see cref="PointF"/>s</returns>
-        private static PointF[] TransformToImage(Coordinate[] vertices, MapViewport map)
-        {
-            var v = new PointF[vertices.Length];
-            for (var i = 0; i < vertices.Length; i++)
-                v[i] = map.WorldToImage(vertices[i]);
-            return v;
+            return Transform.WorldToMap(self.Coordinates,map.WorldToMapTransform(false));
         }
 
         /// <summary>

--- a/SharpMap/Map/MapViewport.cs
+++ b/SharpMap/Map/MapViewport.cs
@@ -314,50 +314,6 @@ namespace SharpMap
         }
 
         /// <summary>
-        /// temporarily retained for benchmarking purposes only
-        /// </summary>
-        [Obsolete]
-        public PointF WorldToImageOld(Coordinate p, bool careAboutMapTransform)
-        {
-            var pTmp = WorldToImage(p);
-            if (!careAboutMapTransform)
-                return pTmp;
-
-            var pts = new[] { pTmp };
-            //Monitor.Enter(_mapTransform);
-            using (var mapTransform = MapTransform)
-            {
-                if (mapTransform.IsIdentity == false)
-                {
-                    mapTransform.TransformPoints(pts);
-                }
-            }
-            //Monitor.Exit(_mapTransform);
-
-            return pts[0];
-        }
-
-        /// <summary>
-        /// temporarily retained for benchmarking purposes only
-        /// </summary>
-        [Obsolete]
-        public PointF WorldToImageOld(Coordinate p)
-        {
-            if (p.IsEmpty())
-                return PointF.Empty;
-
-            double x = (p.X - Left) / PixelWidth;
-            if (double.IsNaN(x))
-                return PointF.Empty;
-
-            double y = (Top - p.Y) / PixelHeight;
-            if (double.IsNaN(y))
-                return PointF.Empty;
-
-            return new PointF((float)x, (float)y);
-        }
-
-        /// <summary>
         /// Creates a map viewport from a given map
         /// </summary>
         /// <param name="map">The map</param>

--- a/SharpMap/Map/MapViewport.cs
+++ b/SharpMap/Map/MapViewport.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using GeoAPI.Geometries;
+using NetTopologySuite.Geometries.Utilities;
 using SharpMap.Utilities;
 
 namespace SharpMap
@@ -17,18 +15,15 @@ namespace SharpMap
         private readonly Envelope _envelope;
         private readonly Coordinate _center;
 
-        //private readonly Matrix _mapTransform;
-        //private readonly Matrix _mapTransformInverted;
-
         private readonly float[] _mapTransformElements;
         private readonly float[] _mapTransformInvertedElements;
 
-        private readonly double _left;
-        private readonly double _top;
+        private readonly double[] _worldToMapElements;
+        private readonly double[] _worldToMapElementsCareAboutTransform;
+
         private double _mapScale;
         private int _lastDpi;
 
-        // TODO: Reconsider computing map scale
         private readonly object _lockMapScale = new object();
 
         /// <summary>
@@ -36,37 +31,49 @@ namespace SharpMap
         /// </summary>
         /// <param name="mapId">The id of the map</param>
         /// <param name="srid">The spatial reference</param>
-        /// <param name="env">The envelope of the viewport</param>
+        /// <param name="zoom">current map zoom</param>
+        /// <param name="mapHeight">map height</param>
+        /// <param name="env">The envelope containing the viewport</param>
         /// <param name="size">The size of the viewport</param>
         /// <param name="pixelAspectRatio">A ratio between width and height</param>
         /// <param name="mapTransform">An affine map transform matrix</param>
         /// <param name="mapTransformInverted">The affine map transformation that inverts <paramref name="mapTransform"/></param>
-        public MapViewport(Guid mapId, int srid, Envelope env, Size size, double pixelAspectRatio, Matrix mapTransform, Matrix mapTransformInverted)
+        /// <param name="mapTransformRotation">The rotation in degrees applied by <paramref name="mapTransform"/></param>
+        public MapViewport(Guid mapId, int srid, double zoom, double mapHeight, Envelope env, Size size, double pixelAspectRatio, 
+            System.Drawing.Drawing2D.Matrix mapTransform, System.Drawing.Drawing2D.Matrix mapTransformInverted,
+            float mapTransformRotation)
         {
             ID = mapId;
             SRID = srid;
+
+            Zoom = zoom;
+            MapHeight = mapHeight;
 
             _envelope = env.Copy();
             Size = size;
             _center = env.Centre;
 
             PixelAspectRatio = pixelAspectRatio;
-            PixelWidth = /*PixelSize = */env.Width/size.Width;
-            PixelHeight = PixelWidth*pixelAspectRatio;
-
-            Zoom = env.Width;
-            MapHeight = Zoom * pixelAspectRatio;
-
-            // already cloned
-            //_mapTransform = mapTransform;
-            //_mapTransformInverted = mapTransformInverted;
+            PixelWidth = Zoom / size.Width; 
+            PixelHeight = PixelWidth * pixelAspectRatio;
 
             _mapTransformElements = mapTransform.Elements;
             _mapTransformInvertedElements = mapTransformInverted.Elements;
+            MapTransformRotation = mapTransformRotation;
 
-            double height = (Zoom * Size.Height) / Size.Width;
-            _left = Center.X - Zoom * 0.5;
-            _top = Center.Y + height * 0.5 * PixelAspectRatio;
+            // pre-calculated for use when MapTransformRotation == 0
+            Left = Center.X - Zoom * 0.5;
+            Top = Center.Y + mapHeight * 0.5;
+
+            // pre-defined for use when MapTransformation != 0
+            if (!mapTransformRotation.Equals(0f))
+            {
+                _worldToMapElements = Transform.WorldToMapMatrix(
+                    Center, PixelWidth, PixelHeight, MapTransformRotation, Size, false).MatrixEntries;
+
+                _worldToMapElementsCareAboutTransform =Transform.WorldToMapMatrix(
+                    Center, PixelWidth, PixelHeight, MapTransformRotation, Size, true).MatrixEntries;
+            }
         }
 
         /// <summary>
@@ -74,7 +81,8 @@ namespace SharpMap
         /// </summary>
         /// <param name="map">The Map</param>
         public MapViewport(Map map)
-            :this(map.ID, map.SRID, map.Envelope, map.Size, map.PixelAspectRatio, map.MapTransform, map.MapTransformInverted)
+            : this(map.ID, map.SRID, map.Zoom, map.MapHeight, map.Envelope, map.Size, map.PixelAspectRatio,
+                map.MapTransform, map.MapTransformInverted, map.MapTransformRotation)
         {
         }
 
@@ -94,33 +102,31 @@ namespace SharpMap
         public Size Size { get; }
 
         /// <summary>
-        /// Gets a value indicating the area covered by the map (in world units)
+        /// <para>Gets the rectilinear extents of the map based on the current <see cref="Zoom"/>,
+        /// <see cref="Center"/>, map <see cref="Size"/>, and (optionally) the <see cref="MapTransform"/></para>
+        /// <para>If a <see cref="MapTransform"/> is applied, the envelope CONTAINING the rotated view
+        /// will be returned (used by layers to spatially select data) and the aspect ratio will NOT be the
+        /// same as map <see cref="Size"/>. If aspect ratio is important then refer to <see cref="Zoom"/>
+        /// and <see cref="MapHeight"/></para> 
         /// </summary>
-        public Envelope Envelope
-        {
-            get { return _envelope.Copy(); }
-        }
+        public Envelope Envelope => _envelope.Copy();
 
         /// <summary>
         /// Gets a value indicating the transformation that has to be applied when
         /// rendering the map
         /// </summary>
-        public Matrix MapTransform
+        public System.Drawing.Drawing2D.Matrix MapTransform
         {
             get
             {
-                //lock (_mapTransform)
-                //{
-                //    return _mapTransform.Clone();
-                //}
-                return new Matrix(
+                return new System.Drawing.Drawing2D.Matrix(
                     _mapTransformElements[0],
                     _mapTransformElements[1],
                     _mapTransformElements[2],
                     _mapTransformElements[3],
                     _mapTransformElements[4],
                     _mapTransformElements[5]
-                    );
+                );
             }
         }
 
@@ -128,28 +134,57 @@ namespace SharpMap
         /// Gets a value indicating the inverse transformation that is applied when
         /// rendering the map
         /// </summary>
-        public Matrix MapTransformInverted
+        public System.Drawing.Drawing2D.Matrix MapTransformInverted
         {
             get
             {
-                return new Matrix(
+                return new System.Drawing.Drawing2D.Matrix(
                     _mapTransformInvertedElements[0],
                     _mapTransformInvertedElements[1],
                     _mapTransformInvertedElements[2],
                     _mapTransformInvertedElements[3],
                     _mapTransformInvertedElements[4],
                     _mapTransformInvertedElements[5]
-                    );
+                );
             }
         }
 
         /// <summary>
+        /// Map rotation in degrees (defined by <see cref="MapTransform"/>)
+        /// </summary>
+        public float MapTransformRotation { get; }
+
+        /// <summary>
+        /// Cached affine transformation used to transform world coordinates from apparent rotated coordinate frame (ie MapTransformRotation != 0)
+        /// to image space. Unlike MapTransform, this matrix defines a complete transformation from World to Image taking into account MapRotation.
+        /// 2 variants are available, depending on whether or not map rotation has already been applied.
+        /// </summary>
+        internal AffineTransformation WorldToMapTransform(bool careAboutTransform)
+        {
+            if (careAboutTransform)
+                return new AffineTransformation(
+                    _worldToMapElementsCareAboutTransform[0],
+                    _worldToMapElementsCareAboutTransform[1],
+                    _worldToMapElementsCareAboutTransform[2],
+                    _worldToMapElementsCareAboutTransform[3],
+                    _worldToMapElementsCareAboutTransform[4],
+                    _worldToMapElementsCareAboutTransform[5]
+                );
+            else
+                return new AffineTransformation(
+                    _worldToMapElements[0],
+                    _worldToMapElements[1],
+                    _worldToMapElements[2],
+                    _worldToMapElements[3],
+                    _worldToMapElements[4],
+                    _worldToMapElements[5]
+                );
+        }
+        
+        /// <summary>
         /// Gets a value indicating the center of the map viewport
         /// </summary>
-        public Coordinate Center
-        {
-            get { return _center.Copy(); }
-        }
+        public Coordinate Center => _center.Copy();
 
         /// <summary>
         /// Gets a value indicating the zoom of the map viewport
@@ -166,7 +201,17 @@ namespace SharpMap
         /// Gets a value indicating the width of the map viewport in world units
         /// </summary>
         /// <remarks>This value is equal to <see cref="Zoom"/></remarks>
-        public double MapWidth { get { return Zoom; } }
+        private double MapWidth => Zoom;
+
+        /// <summary>
+        /// Applicable to non-rotated views only, returning the minimum X value of the map viewport in world units
+        /// </summary>
+        public double Left { get; }
+        
+        /// <summary>
+        /// Applicable to non-rotated views only, returning the maximum Y value of the map viewport in world units
+        /// </summary>
+        public double Top { get; }
 
         /// <summary>
         /// Gets or sets the aspect-ratio of the pixel scales. A value less than 
@@ -174,12 +219,6 @@ namespace SharpMap
         /// </summary>
         /// <exception cref="ArgumentException">Throws an argument exception when value is 0 or less.</exception>
         public double PixelAspectRatio { get; }
-
-        ///// <summary>
-        ///// Get Returns the size of a pixel in world coordinate units
-        ///// </summary>
-        //[Obsolete("Use PixelWidth or PixelHeight")]
-        //public double PixelSize { get; private set; }
 
         /// <summary>
         /// Returns the width of a pixel in world coordinate units.
@@ -198,26 +237,87 @@ namespace SharpMap
         /// <returns>The scale's denominator</returns>
         public double GetMapScale(int dpi)
         {
-            // Why lock?
-            lock (_lockMapScale)
+            if (_lastDpi != dpi)
             {
-                if (_lastDpi != dpi)
-                {
-                    _mapScale = ScaleCalculations.CalculateScaleNonLatLong(Envelope.Width, Size.Width, 1, dpi);
-                    _lastDpi = dpi;
-                }
-                return _mapScale;
+                lock (_lockMapScale)
+                    if (_lastDpi != dpi)
+                    {
+                        _mapScale = ScaleCalculations.CalculateScaleNonLatLong(Zoom, Size.Width, 1, dpi);
+                        _lastDpi = dpi;
+                    }
             }
+
+            return _mapScale;
         }
 
         /// <summary>
-        /// Converts a point from world coordinates to image coordinates based on the current
-        /// <see cref="Zoom"/>, <see cref="Center"/> and <see cref="Size"/>.
+        /// Converts an array of world coordinates to image coordinates based on the current <see cref="Zoom"/>, <see cref="Center"/>,
+        /// map <see cref="Size"/>, and (optionally) the <see cref="MapTransform"/>.
+        /// </summary>
+        /// <param name="coordinates">Coordinate array in world coordinates</param>
+        /// <param name="careAboutMapTransform">Indicates whether <see cref="MapTransform"/> should be applied. True for typical coordinate calcs,
+        /// False when rendering to image as the Graphics object has already applied the MapTransform</param>
+        /// <returns>PointF array in image coordinates</returns>
+        public PointF[] WorldToImage(Coordinate[] coordinates, bool careAboutMapTransform = false)
+        {
+            // see WorldToImage discussion in Map.cs. This is a slightly shortened form using cached values.
+            if (MapTransformRotation.Equals(0f))
+                return Transform.WorldToMap(coordinates, Left, Top, PixelWidth, PixelHeight);
+
+            var matrix = WorldToMapTransform(careAboutMapTransform);
+            return Transform.WorldToMap(coordinates, matrix);
+        }
+        
+        /// <summary>
+        /// Converts a point in world coordinates to image coordinates based on the current <see cref="Zoom"/>, <see cref="Center"/>,
+        /// map <see cref="Size"/>, and (optionally) the <see cref="MapTransform"/>.
         /// </summary>
         /// <param name="p">Point in world coordinates</param>
-        /// <param name="careAboutMapTransform">Indicates whether MapTransform should be taken into account</param>
-        /// <returns>Point in image coordinates</returns>
-        public PointF WorldToImage(Coordinate p, bool careAboutMapTransform)
+        /// <param name="careAboutMapTransform">Indicates whether <see cref="MapTransform"/> should be applied. When rendering to image,
+        /// the Graphics object has usually applied MapTransform</param>
+        /// <returns>PointF in image coordinates</returns>
+        public PointF WorldToImage(Coordinate p, bool careAboutMapTransform = false)
+        {
+            var points = WorldToImage(new Coordinate[] {p}, careAboutMapTransform);
+            return points[0];
+        }
+
+        /// <summary>
+        /// Converts a point array from image coordinates to world coordinates based on the current <see cref="Zoom"/>, <see cref="Center"/>,
+        /// map <see cref="Size"/>, and (optionally) the <see cref="MapTransform"/>.
+        /// </summary>
+        /// <param name="points">Point array in image coordinates. Note: if you wish to preserve the input values then
+        /// you must clone the point array as it will be modified if a MapTransform is applied</param>
+        /// <param name="careAboutMapTransform">Indicates whether <see cref="MapTransform"/> should be applied. </param>
+        /// <returns>Point array in world coordinates</returns>
+        public Coordinate[] ImageToWorld(PointF[] points, bool careAboutMapTransform = false)
+        {
+            if (careAboutMapTransform && !MapTransformRotation.Equals(0f))
+                using (var transformInv = MapTransformInverted)
+                    transformInv.TransformPoints(points);
+
+            return Transform.MapToWorld(points, Center, Zoom, MapHeight, PixelWidth, PixelHeight);
+        }
+
+        /// <summary>
+        /// Converts a point from image coordinates to world coordinates based on the current <see cref="Zoom"/>, <see cref="Center"/>,
+        /// map <see cref="Size"/>, and (optionally) the <see cref="MapTransform"/>.
+        /// </summary>
+        /// <param name="p">Point in image coordinates. Note: if you wish to preserve the input value then
+        /// you must clone the point as it will be modified if a MapTransform is applied</param>
+        /// <param name="careAboutMapTransform">Indicates whether <see cref="MapTransform"/> should be applied. </param>
+        /// <returns>Point in world coordinates</returns>
+        public Coordinate ImageToWorld(PointF p, bool careAboutMapTransform = false)
+        {
+            var pts = ImageToWorld(new PointF[] {p}, careAboutMapTransform);
+            return pts[0];
+        }
+
+        /// <summary>
+        /// temporarily retained for benchmarking purposes only
+        /// </summary>
+        [Obsolete]
+        public PointF WorldToImageOld(Coordinate p, bool careAboutMapTransform)
         {
             var pTmp = WorldToImage(p);
             if (!careAboutMapTransform)
@@ -238,58 +338,23 @@ namespace SharpMap
         }
 
         /// <summary>
-        /// Converts a point from world coordinates to image coordinates based on the current
-        /// <see cref="Zoom"/>, <see cref="Center"/> and <see cref="Size"/>.
+        /// temporarily retained for benchmarking purposes only
         /// </summary>
-        /// <param name="p">Point in world coordinates</param>
-        /// <returns>Point in image coordinates</returns>
-        public PointF WorldToImage(Coordinate p)
+        [Obsolete]
+        public PointF WorldToImageOld(Coordinate p)
         {
             if (p.IsEmpty())
                 return PointF.Empty;
 
-            double x = (p.X - _left) / PixelWidth;
+            double x = (p.X - Left) / PixelWidth;
             if (double.IsNaN(x))
                 return PointF.Empty;
 
-            double y = (_top - p.Y) / PixelHeight;
+            double y = (Top - p.Y) / PixelHeight;
             if (double.IsNaN(y))
                 return PointF.Empty;
 
             return new PointF((float)x, (float)y);
-        }
-
-        /// <summary>
-        /// Converts a point from image coordinates to world coordinates based on the current
-        /// <see cref="Zoom"/>, <see cref="Center"/> and <see cref="Size"/>.
-        /// </summary>
-        /// <param name="p">Point in image coordinates</param>
-        /// <returns>Point in world coordinates</returns>
-        public Coordinate ImageToWorld(PointF p)
-        {
-            return ImageToWorld(p, false);
-        }
-        /// <summary>
-        /// Converts a point from image coordinates to world coordinates based on the current
-        /// <see cref="Zoom"/>, <see cref="Center"/> and <see cref="Size"/>.
-        /// </summary>
-        /// <param name="p">Point in image coordinates</param>
-        /// <param name="careAboutMapTransform">Indicates whether MapTransform should be taken into account</param>
-        /// <returns>Point in world coordinates</returns>
-        public Coordinate ImageToWorld(PointF p, bool careAboutMapTransform)
-        {
-            var pts = new[] { p };
-            //Monitor.Enter(_mapTransformInverted);
-            using (var mapTransformInverted = MapTransformInverted)
-            {
-                if (mapTransformInverted.IsIdentity == false)
-                {
-                    mapTransformInverted.TransformPoints(pts);
-                }
-            }
-            //Monitor.Exit(_mapTransformInverted);
-
-            return Transform.MapToWorld(pts[0], this);
         }
 
         /// <summary>
@@ -300,9 +365,6 @@ namespace SharpMap
         public static implicit operator MapViewport(Map map)
         {
             return new MapViewport(map);
-            //return new MapViewport(map.ID, map.SRID, map.Envelope, map.Size, map.PixelAspectRatio, 
-            //                       map.MapTransform, map.MapTransformInverted);
         }
-
     }
 }

--- a/SharpMap/Rendering/Decoration/Disclaimer.cs
+++ b/SharpMap/Rendering/Decoration/Disclaimer.cs
@@ -94,7 +94,7 @@ namespace SharpMap.Rendering.Decoration
         /// <param name="g"></param>
         /// <param name="map"></param>
         /// <returns>The</returns>
-        protected override Size InternalSize(Graphics g, Map map)
+        protected override Size InternalSize(Graphics g, MapViewport map)
         {
             var s = g.MeasureString(Text, Font);
             return new Size((int)Math.Ceiling(s.Width), (int)Math.Ceiling(s.Height));
@@ -105,14 +105,15 @@ namespace SharpMap.Rendering.Decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected override void OnRender(Graphics g, Map map)
+        protected override void OnRender(Graphics g, MapViewport map)
         {
             var layoutRectangle = g.ClipBounds;
             var b = new SolidBrush(OpacityColor(ForeColor));
             if (Halo > 0)
             {
                 var gp = new GraphicsPath();
-                gp.AddString(Text, Font.FontFamily, (int)Font.Style, Utility.ScaleSizeToDeviceUnits(Font.SizeInPoints, GraphicsUnit.Point, g), layoutRectangle, Format);
+                gp.AddString(Text, Font.FontFamily, (int) Font.Style,
+                    Utility.ScaleSizeToDeviceUnits(Font.SizeInPoints, GraphicsUnit.Point, g), layoutRectangle, Format);
                 g.DrawPath(_halo, gp);
                 g.FillPath(b, gp);
             }
@@ -120,7 +121,7 @@ namespace SharpMap.Rendering.Decoration
                 g.DrawString(Text, Font, b, layoutRectangle);
 
         }
-
+        
         #endregion
     }
 }

--- a/SharpMap/Rendering/Decoration/Disclaimer.cs
+++ b/SharpMap/Rendering/Decoration/Disclaimer.cs
@@ -87,24 +87,12 @@ namespace SharpMap.Rendering.Decoration
 
         #region MapDecoration overrides
 
-        /// <summary>
-        /// Function to compute the required size for rendering the map decoration object
-        /// <para>This is just the size of the decoration object, border settings are excluded</para>
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
-        /// <returns>The</returns>
         protected override Size InternalSize(Graphics g, MapViewport map)
         {
             var s = g.MeasureString(Text, Font);
             return new Size((int)Math.Ceiling(s.Width), (int)Math.Ceiling(s.Height));
         }
 
-        /// <summary>
-        /// Function to render the actual map decoration
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
         protected override void OnRender(Graphics g, MapViewport map)
         {
             var layoutRectangle = g.ClipBounds;

--- a/SharpMap/Rendering/Decoration/EyeOfSight.cs
+++ b/SharpMap/Rendering/Decoration/EyeOfSight.cs
@@ -67,7 +67,7 @@ namespace SharpMap.Rendering.Decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected override void OnRender(Graphics g, Map map)
+        protected override void OnRender(Graphics g, MapViewport map)
         {
             // Render the rosetta
             base.OnRender(g, map);
@@ -81,13 +81,13 @@ namespace SharpMap.Rendering.Decoration
             var width = Size.Width;
             var height = Size.Height;
             var pts = new[]
-                          {
-                              new PointF(0f, -0.35f*height),
-                              new PointF(0.125f*width, 0.35f*height),
-                              new PointF(0f, 0.275f*height),
-                              new PointF(-0.125f*width, 0.35f*height),
-                              new PointF(0f, -0.35f*height),
-                          };
+            {
+                new PointF(0f, -0.35f*height),
+                new PointF(0.125f*width, 0.35f*height),
+                new PointF(0f, 0.275f*height),
+                new PointF(-0.125f*width, 0.35f*height),
+                new PointF(0f, -0.35f*height),
+            };
 
             // need to outline the needle
             if (NeedleOutlineWidth>0)
@@ -99,9 +99,8 @@ namespace SharpMap.Rendering.Decoration
             g.FillPolygon(new SolidBrush(OpacityColor(NeedleFillColor)), pts );
 
             g.Transform = oldTransform;
-
         }
-        
+
         #endregion
     }
 }

--- a/SharpMap/Rendering/Decoration/EyeOfSight.cs
+++ b/SharpMap/Rendering/Decoration/EyeOfSight.cs
@@ -62,18 +62,13 @@ namespace SharpMap.Rendering.Decoration
 
         #region MapDecoration overrides
 
-        /// <summary>
-        /// Function to render the actual map decoration
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
         protected override void OnRender(Graphics g, MapViewport map)
         {
             // Render the rosetta
             base.OnRender(g, map);
             
             var clip = g.ClipBounds;
-            var oldTransform = g.Transform;
+            //var oldTransform = g.Transform;
             var newTransform = new Matrix(1f, 0f, 0f, 1f, clip.Left + Size.Width*0.5f, clip.Top + Size.Height*0.5f);
 
             g.Transform = newTransform;
@@ -98,7 +93,7 @@ namespace SharpMap.Rendering.Decoration
             // need to outline the needle
             g.FillPolygon(new SolidBrush(OpacityColor(NeedleFillColor)), pts );
 
-            g.Transform = oldTransform;
+            //g.Transform = oldTransform;
         }
 
         #endregion

--- a/SharpMap/Rendering/Decoration/IMapDecoration.cs
+++ b/SharpMap/Rendering/Decoration/IMapDecoration.cs
@@ -9,10 +9,15 @@ namespace SharpMap.Rendering.Decoration
     public interface IMapDecoration
     {
         /// <summary>
-        /// Renders the map decoration to the graphics object
+        /// Draw the map decoration.
+        /// <para>Note that base class <see cref="MapDecoration"/> implementation resets <paramref name="g"/>.Transform
+        /// prior to raising event OnRendering, and restore the <paramref name="g"/>.Transform prior to
+        /// raising event OnRendered.</para>
+        /// Likewise, <paramref name="g"/>.Clip is reset prior to rendering map decoration, and restored
+        /// immediately after rendering.
         /// </summary>
-        /// <param name="g">The graphics object</param>
-        /// <param name="map">The map viewport</param>
+        /// <param name="g"></param>
+        /// <param name="map"></param>
         void Render(Graphics g, MapViewport map);
 
         [Obsolete("Use Render (Graphics, MapViewport)")]

--- a/SharpMap/Rendering/Decoration/IMapDecoration.cs
+++ b/SharpMap/Rendering/Decoration/IMapDecoration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 
 namespace SharpMap.Rendering.Decoration
@@ -11,7 +12,10 @@ namespace SharpMap.Rendering.Decoration
         /// Renders the map decoration to the graphics object
         /// </summary>
         /// <param name="g">The graphics object</param>
-        /// <param name="map">The map</param>
+        /// <param name="map">The map viewport</param>
+        void Render(Graphics g, MapViewport map);
+
+        [Obsolete("Use Render (Graphics, MapViewport)")]
         void Render(Graphics g, Map map);
     }
 }

--- a/SharpMap/Rendering/Decoration/MapDecoration.cs
+++ b/SharpMap/Rendering/Decoration/MapDecoration.cs
@@ -60,7 +60,7 @@ namespace SharpMap.Rendering.Decoration
         /// </summary>
         /// <param name="map"></param>
         /// <returns></returns>
-        private Point GetLocation(Map map)
+        private Point GetLocation(MapViewport map)
         {
             var clipRect = map.Size;
             var objectSize = Size;
@@ -156,7 +156,7 @@ namespace SharpMap.Rendering.Decoration
         /// </summary>
         public bool RoundedEdges { get; set; }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Function to compute the required size for rendering the map decoration object
@@ -165,9 +165,15 @@ namespace SharpMap.Rendering.Decoration
         /// <param name="g">The graphics object</param>
         /// <param name="map">The map</param>
         /// <returns>The size of the map decoration</returns>
-        protected abstract Size InternalSize(Graphics g, Map map);
+        protected abstract Size InternalSize(Graphics g, MapViewport map);
 
-        private void CalcMapDecorationMetrics(Graphics g, Map map)
+        [Obsolete("Use InternalSize(Graphics, MapViewport")]
+        protected virtual Size InternalSize(Graphics g, Map map)
+        {
+            return InternalSize(g, (MapViewport) map);
+        }
+
+        private void CalcMapDecorationMetrics(Graphics g, MapViewport map)
         {
             _cachedSize = InternalSize(g, map);
             var rect = new Rectangle(Point.Add(GetLocation(map), BorderMargin), _cachedSize);
@@ -179,7 +185,7 @@ namespace SharpMap.Rendering.Decoration
             get { return Size.Add(_cachedSize, Size.Add(BorderMargin, BorderMargin)); }
         }
 
-        private Region GetClipRegion(Map map)
+        private Region GetClipRegion(MapViewport map)
         {
             return new Region(new Rectangle(Point.Add(GetLocation(map), BorderMargin), _cachedSize));
         }
@@ -216,12 +222,13 @@ namespace SharpMap.Rendering.Decoration
             return gp;
         }
 
+
         /// <summary>
-        /// 
+        /// Draw the map decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        public void Render(Graphics g, Map map)
+        public void Render(Graphics g, MapViewport map)
         {
             //Is this map decoration enabled?
             if (!Enabled)
@@ -257,30 +264,57 @@ namespace SharpMap.Rendering.Decoration
             OnRendered(g, map);
         }
 
+        [Obsolete("Use Render(Graphics, MapViewport")]
+        public void Render(Graphics g, Map map)
+        {
+            Render(g, (MapViewport)map);
+        }
+
+
         /// <summary>
         /// Function to render the actual map decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected virtual void OnRender(Graphics g, Map map)
+        protected virtual void OnRender(Graphics g, MapViewport map)
         {
         }
+
+        [Obsolete("Use OnRender(Graphics, MapViewport")]
+        protected virtual void OnRender(Graphics g, Map map)
+        {
+            OnRender(g, (MapViewport) map);
+        }
+
         /// <summary>
         /// Function to render the actual map decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected virtual void OnRendering(Graphics g, Map map)
+        protected virtual void OnRendering(Graphics g, MapViewport map)
         {
             CalcMapDecorationMetrics(g, map);
         }
+
+        [Obsolete("Use OnRendering(Graphics, MapViewport")]
+        protected virtual void OnRendering(Graphics g, Map map)
+        {
+            OnRendering(g, (MapViewport)map);
+        }
+
         /// <summary>
         /// Function to render the actual map decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
+        protected virtual void OnRendered(Graphics g, MapViewport map)
+        {
+        }
+
+        [Obsolete("Use OnRendered(Graphics, MapViewport")]
         protected virtual void OnRendered(Graphics g, Map map)
         {
+            OnRendered(g, (MapViewport) map);
         }
     }
 }

--- a/SharpMap/Rendering/Decoration/MapDecoration.cs
+++ b/SharpMap/Rendering/Decoration/MapDecoration.cs
@@ -222,18 +222,16 @@ namespace SharpMap.Rendering.Decoration
             return gp;
         }
 
-
-        /// <summary>
-        /// Draw the map decoration
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
         public void Render(Graphics g, MapViewport map)
         {
             //Is this map decoration enabled?
             if (!Enabled)
                 return;
 
+            // remove any image to world rotation
+            var oldTransform = g.Transform;
+            g.ResetTransform();
+            
             //Preparing rendering
             OnRendering(g, map);
 
@@ -258,7 +256,9 @@ namespace SharpMap.Rendering.Decoration
 
             //Restore old clip region
             g.Clip = oldClip;
-
+            
+            // restore any image to world rotation
+            g.Transform = oldTransform;
 
             //Finished rendering
             OnRendered(g, map);
@@ -272,7 +272,8 @@ namespace SharpMap.Rendering.Decoration
 
 
         /// <summary>
-        /// Function to render the actual map decoration
+        /// Render the actual map decoration.
+        /// <para>Refer to MapDecoration.<see cref="Render(System.Drawing.Graphics,SharpMap.MapViewport)"/> for underlying management of <paramref name="g"/>.Transform</para> 
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
@@ -287,7 +288,8 @@ namespace SharpMap.Rendering.Decoration
         }
 
         /// <summary>
-        /// Function to render the actual map decoration
+        /// Signal commencing rendering
+        /// <para>Refer to MapDecoration.<see cref="Render(System.Drawing.Graphics,SharpMap.MapViewport)"/> for underlying management of <paramref name="g"/>.Transform</para> 
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
@@ -303,7 +305,8 @@ namespace SharpMap.Rendering.Decoration
         }
 
         /// <summary>
-        /// Function to render the actual map decoration
+        /// Signal completion of rendering
+        /// <para>Refer to MapDecoration.<see cref="Render(System.Drawing.Graphics,SharpMap.MapViewport)"/> for underlying management of <paramref name="g"/>.Transform</para> 
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>

--- a/SharpMap/Rendering/Decoration/NorthArrow.cs
+++ b/SharpMap/Rendering/Decoration/NorthArrow.cs
@@ -60,6 +60,7 @@ namespace SharpMap.Rendering.Decoration
         /// </summary>
         public Size Size { get; set; }
 
+
         /// <summary>
         /// Gets or sets the fore color
         /// </summary>
@@ -75,17 +76,17 @@ namespace SharpMap.Rendering.Decoration
         /// <param name="g">The graphics object</param>
         /// <param name="map">The map</param>
         /// <returns>The size of the map decoration</returns>
-        protected override Size InternalSize(Graphics g, Map map)
+        protected override Size InternalSize(Graphics g, MapViewport map)
         {
             return Size;
         }
-
+        
         /// <summary>
         /// Function to render the actual map decoration
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected override void OnRender(Graphics g, Map map)
+        protected override void OnRender(Graphics g, MapViewport map)
         {
             var image = NorthArrowImage ?? DefaultNorthArrowBitmap;
 
@@ -107,8 +108,8 @@ namespace SharpMap.Rendering.Decoration
             
             var clip = g.ClipBounds;
             var newTransform = new Matrix(1f, 0f, 0f, 1f, 
-                                          clip.Left + halfSize.Width,
-                                          clip.Top + halfSize.Height);
+                clip.Left + halfSize.Width,
+                clip.Top + halfSize.Height);
             newTransform.Rotate((float)rot);
 
             // Setup image attributes

--- a/SharpMap/Rendering/Decoration/NorthArrow.cs
+++ b/SharpMap/Rendering/Decoration/NorthArrow.cs
@@ -69,23 +69,11 @@ namespace SharpMap.Rendering.Decoration
 
         #region MapDecoration overrides
 
-        /// <summary>
-        /// Function to compute the required size for rendering the map decoration object
-        /// <para>This is just the size of the decoration object, border settings are excluded</para>
-        /// </summary>
-        /// <param name="g">The graphics object</param>
-        /// <param name="map">The map</param>
-        /// <returns>The size of the map decoration</returns>
         protected override Size InternalSize(Graphics g, MapViewport map)
         {
             return Size;
         }
         
-        /// <summary>
-        /// Function to render the actual map decoration
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
         protected override void OnRender(Graphics g, MapViewport map)
         {
             var image = NorthArrowImage ?? DefaultNorthArrowBitmap;
@@ -104,7 +92,7 @@ namespace SharpMap.Rendering.Decoration
 
             var rot = -90 + (dy > 0 ? -1 : 1) * Math.Acos(cos) / GeoSpatialMath.DegToRad;
             var halfSize = new Size((int)(0.5f*Size.Width), (int)(0.5f*Size.Height));
-            var oldTransform = g.Transform;
+            //var oldTransform = g.Transform;
             
             var clip = g.ClipBounds;
             var newTransform = new Matrix(1f, 0f, 0f, 1f, 
@@ -125,7 +113,7 @@ namespace SharpMap.Rendering.Decoration
             var rect = new Rectangle(-halfSize.Width, -halfSize.Height, Size.Width, Size.Height);
             g.DrawImage(image, rect, 0, 0, image.Size.Width, image.Size.Height, GraphicsUnit.Pixel, ia);
 
-            g.Transform = oldTransform;
+            //g.Transform = oldTransform;
         }
 
         #endregion

--- a/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
+++ b/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
@@ -18,7 +18,9 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
 */
 
     /// <summary>
-    /// Scale Bar map decoration
+    /// Scale Bar map decoration.
+    /// <para>Ensure that appropriate <see cref="MapUnit"/> is set</para>
+    /// Also ensure Map.SRID is set appropriately to enable Web Mercator latitude adjustment.
     /// </summary>
     [Serializable]
     public class ScaleBar : MapDecoration
@@ -46,8 +48,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         private const int DefaultWidth = 180;
 
         private const double VerySmall = 0.0000001;
-
-        private const double WebMercatorRadius = 6378137.0;
 
         #endregion
 
@@ -121,13 +121,7 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
 
         #region MapDecoration overrides
 
-        /// <summary>
-        /// Function to compute the required size for rendering the map decoration object
-        /// <para>This is just the size of the decoration object, border settings are excluded</para>
-        /// </summary>
-        /// <param name="g">The graphics object</param>
-        /// <param name="map">The mapviewport</param>
-        /// <returns>The size of the map decoration</returns>
+
         protected override Size InternalSize(Graphics g, MapViewport map)
         {
             CalcScale((int)g.DpiX);
@@ -136,33 +130,31 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             return new Size((int)width, (int)height);
         }
 
-        /// <summary>
-        /// Function to render the actual map decoration. Note special handling when Map.SRID=3857 (WebMercator)
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="map"></param>
         protected override void OnRender(Graphics g, MapViewport map)
         {
             var rectF = g.ClipBounds;
-
+            
             if (MapUnit == (int)Unit.Degree)
             {
-                var p1 = map.ImageToWorld(new PointF(0, map.Size.Height * 0.5f));
-                var p2 = map.ImageToWorld(new PointF(map.Size.Width, map.Size.Height * 0.5f));
-                SetScaleD((int)g.DpiX, p1.X, p2.X, p1.Y, map.Size.Width);
+                // do not use map.Envelope as this is not apparent width on rotated viewports
+                var lon1 = map.Center.X - map.Zoom * 0.5;
+                var lon2 = map.Center.X + map.Zoom * 0.5;
+                SetScaleD((int)g.DpiX, lon1, lon2, map.Center.Y, map.Size.Width);
             }
             else
-                SetScale((int)g.DpiX, map.Envelope.Width, map.Size.Width);
+            {
+                SetScale((int)g.DpiX, map.Zoom, map.Size.Width);
+            }
 
             switch (map.SRID)
             {
                 case 3857: 
                     //other spherical variations (all of which are deprecated except 900913): 900913 54004 41001 102113 102100 3785 
-                    var midGrid = map.ImageToWorld(new PointF(map.Size.Width * 0.5f, map.Size.Height * 0.5f));
+
                     // constrain to 85deg N/S
-                    if (Math.Abs(midGrid.Y) >= 20000000) return;
+                    if (Math.Abs(map.Center.Y) >= 20000000) return;
                     // refer to https://en.wikipedia.org/wiki/Mercator_projection#Scale_factor
-                    _webMercatorFactor = 1 / Math.Cosh(midGrid.Y / WebMercatorRadius);
+                    _webMercatorFactor = 1 / Math.Cosh(map.Center.Y / GeoSpatialMath.WebMercatorRadius);
                     break;
 
                 default:
@@ -172,6 +164,8 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
 
             var rect = new Rectangle(Point.Truncate(rectF.Location), Size.Truncate(rectF.Size));
             RenderScaleBar(g, rect);
+
+            Dirty = false;
         }
 
         #endregion
@@ -207,7 +201,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             RenderSegmentText(g, rc.Left + nOffsetX, rc.Top + nOffsetY + _barWidth + GapBarToSegmentText, _numTics, pixelsPerTic,
                               scaleBarUnitsPerTick,
                               _barUnitShortName);
-            Dirty = false;
         }
 
         /// <summary>
@@ -470,8 +463,78 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             }
         }
 
+private void CalcLargeOrSmallUnit(int dpi, int widthOnDevice, int numTics, double mapScale, double fBarUnitFactor,
+            out int pixelsPerTic, out double scaleBarUnitsPerTic)
+        {
+            if (_forceRecalc)
+            {
+                // revert to large scale unit
+                _barUnit = BarUnitLargeScale;
+                _barUnitFactor = _barUnitFactorLargeScale;
+                _barUnitName = _barUnitNameLargeScale;
+                _barUnitShortName = _barUnitShortNameLargeScale;
+                _forceRecalc = false;
+            }
 
-        #endregion
+            CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactor, out pixelsPerTic, out scaleBarUnitsPerTic);
+
+            if (BarUnitLargeScale != BarUnitSmallScale)
+            {
+                if (_barUnitFactor == _barUnitFactorSmallScale)
+                {
+                    // currently on SmallScale units...
+                    // check how many scale bar units if using LargeScale unit
+                    CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactorLargeScale,
+                        out int chkPixelsPerTick, out double chkScaleBarUnitsPerTic);
+
+                    // check if LargeScale bar length < 1 SmallScale unit
+                    if (NumTicks * chkScaleBarUnitsPerTic * _barUnitFactorLargeScale < _barUnitFactorSmallScale)
+                    {
+                        // switch to LargeScale units
+                        _barUnit = _barUnitLargeScale;
+                        _barUnitFactor = _barUnitFactorLargeScale;
+                        _barUnitName = _barUnitNameLargeScale;
+                        _barUnitShortName = _barUnitShortNameLargeScale;
+
+                        pixelsPerTic = chkPixelsPerTick;
+                        scaleBarUnitsPerTic = chkScaleBarUnitsPerTic;
+                    }
+                }
+                else
+                {
+                    // currently on LargeScale units...
+                    // check if LargeScale bar length >= 1 SmallScale unit (ie LargeScale units never exceed 1 SmallScale unit)
+                    if (NumTicks * scaleBarUnitsPerTic * _barUnitFactorLargeScale >= _barUnitFactorSmallScale)
+                    {
+                        // recalc for SmallScale unit
+                        CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactorSmallScale,
+                            out pixelsPerTic, out scaleBarUnitsPerTic);
+
+                        // switch to SmallScale units
+                        _barUnit = _barUnitSmallScale;
+                        _barUnitFactor = _barUnitFactorSmallScale;
+                        _barUnitName = _barUnitNameSmallScale;
+                        _barUnitShortName = _barUnitShortNameSmallScale;
+                    }
+                }
+            }
+        }
+
+        private void CalcBarScale(int dpi, int widthOnDevice, int numTics, double mapScale, double fBarUnitFactor,
+            out int pixelsPerTic, out double scaleBarUnitsPerTic)
+        {
+            int minPixelsPerTic = widthOnDevice / (numTics * 2);
+            double barScale = mapScale / fBarUnitFactor;
+            int pixelsPerInch = dpi;
+            double barUnitsPerPixel = barScale * GeoSpatialMath.MetersPerInch / pixelsPerInch;
+
+            //calculate the result
+            barUnitsPerPixel *= _webMercatorFactor;
+
+            scaleBarUnitsPerTic = minPixelsPerTic * barUnitsPerPixel;
+            scaleBarUnitsPerTic = GetRoundIncrement(scaleBarUnitsPerTic);
+            pixelsPerTic = (int)(scaleBarUnitsPerTic / barUnitsPerPixel);
+        }
 
         /// <summary>
         /// Renders the verbal text above the scale bar.
@@ -489,13 +552,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                                  new StringFormat
                                  { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Far }, ref lastX);
         }
-
-        private static readonly StringFormat TopCenter =
-            new StringFormat
-            {
-                LineAlignment = StringAlignment.Near,
-                Alignment = StringAlignment.Center
-            };
 
         /// <summary>
         /// Renders the segment text below the scale bar
@@ -609,8 +665,58 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 fScale = ScaleCalculations.CalculateScaleLatLong(_lon1, _lon2, _lat, _pageWidth, dpi);
             else
                 fScale = ScaleCalculations.CalculateScaleNonLatLong(_mapWidth, _pageWidth, _mapUnitFactor, dpi);
-            _scale = fScale;
+            Scale = fScale;
         }
+        
+        private void SetScaleD(int dpi, double lon1, double lon2, double lat, int widthInPixel)
+        {
+            _lon1 = lon1;
+            _lon2 = lon2;
+            _lat = lat;
+            _pageWidth = widthInPixel;
+            CalcScale(dpi);
+        }
+
+        private void SetScale(int dpi, double mapWidth, int widthInPixel)
+        {
+            _mapWidth = mapWidth;
+            _pageWidth = widthInPixel;
+            CalcScale(dpi);
+        }
+
+        private string ScaleBarText(double scale, ScaleBarLabelText scaleText)
+        {
+            switch (scaleText)
+            {
+                case ScaleBarLabelText.NoText:
+                    return string.Empty;
+                case ScaleBarLabelText.JustUnits:
+                    return _barUnitName;
+                default:
+                    var precision = 0;
+
+                    scale *= _webMercatorFactor;
+
+                    //set the precision. Keep the first 5 (ScalePrecisionDigits) digits. 
+                    if (scale > 0)
+                    {
+                        var magnitude = (int)(Math.Log10(scale));
+                        precision = ScalePrecisionDigits - magnitude;
+                        if (precision < 0)
+                            precision = 0;
+                        if (magnitude >= 2)
+                            //don't show the precision if the scale is less than than 1:100 (e.g. 1:1000)
+                            precision = 0;
+
+                    }
+                    var format = string.Format("N{0}", precision);
+
+                    scale = FormatRealScale(scale);
+                    return "1 : " + scale.ToString(format, System.Globalization.CultureInfo.CurrentCulture);
+            }
+        }
+
+        #endregion
 
         /// <summary>
         /// Gets or sets the foreground color, used to render the labeling
@@ -622,7 +728,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _foreColor = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -638,7 +743,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                     return;
                 _font = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -652,7 +756,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barColor1 = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -666,7 +769,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barColor2 = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -681,7 +783,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 if (value < 1) value = 1;
                 _barWidth = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -698,9 +799,11 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         private string _barUnitName, _barUnitShortName;
         private string _barUnitNameLargeScale, _barUnitShortNameLargeScale;
         private string _barUnitNameSmallScale, _barUnitShortNameSmallScale;
+        private int _width;
 
         /// <summary>
-        /// Map unit
+        /// World coordinate system unit. You must set this appropriately as it is NOT deduced from Map.SRID.
+        /// <para>Typically meters (1) for projected coordinate systems, or degrees (7) for geographic coordinate systems.</para>
         /// </summary>
         public int MapUnit
         {
@@ -711,7 +814,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 GetUnitInformation(_mapUnit, out _mapUnitFactor, out _mapUnitName, out _mapUnitShortName);
                 CalcScale(96);
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -800,7 +902,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 _forceRecalc = true;
                 CalcScale(96);
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -819,7 +920,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 _forceRecalc = true;
                 CalcScale(96);
                 OnViewChanged();
-                Dirty = true;
             }
         }
         private static void GetUnitInformation(int mapUnit, out double mapUnitFactor, out string mapUnitName,
@@ -851,7 +951,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barOutline = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -865,7 +964,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barOutlineColor = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -875,11 +973,12 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         public double Scale
         {
             get { return _scale; }
-            set
+            private set
             {
+                if (_scale == value) return;
+                    
                 _scale = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -930,23 +1029,7 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         }
         */
 
-        private void SetScaleD(int dpi, double lon1, double lon2, double lat, int widthInPixel)
-        {
-            _lon1 = lon1;
-            _lon2 = lon2;
-            _lat = lat;
-            _pageWidth = widthInPixel;
-            CalcScale(dpi);
-            OnViewChanged();
-        }
-
-        private void SetScale(int dpi, double mapWidth, int widthInPixel)
-        {
-            _mapWidth = mapWidth;
-            _pageWidth = widthInPixel;
-            CalcScale(dpi);
-            OnViewChanged();
-        }
+        
 
         /// <summary>
         /// Gets or sets the number of ticks
@@ -959,7 +1042,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 if (value < 1) value = 1;
                 _numTics = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -973,44 +1055,21 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barLabelText = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
         /// <summary>
         /// Gets or sets the width of the scale bar
         /// </summary>
-        public int Width { get; set; }
-
-        private string ScaleBarText(double scale, ScaleBarLabelText scaleText)
+        public int Width
         {
-            switch (scaleText)
+            get => _width;
+            set
             {
-                case ScaleBarLabelText.NoText:
-                    return string.Empty;
-                case ScaleBarLabelText.JustUnits:
-                    return _barUnitName;
-                default:
-                    var precision = 0;
+                if (_width == value) return;
 
-                    scale *= _webMercatorFactor;
-
-                    //set the precision. Keep the first 5 (ScalePrecisionDigits) digits. 
-                    if (scale > 0)
-                    {
-                        var magnitude = (int)(Math.Log10(scale));
-                        precision = ScalePrecisionDigits - magnitude;
-                        if (precision < 0)
-                            precision = 0;
-                        if (magnitude >= 2)
-                            //don't show the precision if the scale is less than than 1:100 (e.g. 1:1000)
-                            precision = 0;
-
-                    }
-                    var format = string.Format("N{0}", precision);
-
-                    scale = FormatRealScale(scale);
-                    return "1 : " + scale.ToString(format, System.Globalization.CultureInfo.CurrentCulture);
+                _width = value;
+                OnViewChanged();
             }
         }
 
@@ -1024,7 +1083,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _barStyle = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -1038,7 +1096,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _marginLeft = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
@@ -1052,17 +1109,17 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             {
                 _marginRight = value;
                 OnViewChanged();
-                Dirty = true;
             }
         }
 
         #region EventInvokers
 
         /// <summary>
-        /// Is this required?
+        /// Signal that properties have changed
         /// </summary>
         private void OnViewChanged()
         {
+            Dirty = true;
         }
 
         /// <summary>
@@ -1071,9 +1128,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         public bool Dirty { get; private set; }
 
         #endregion
-
-
-        #region Private static helpers
 
         private class UnitInfo
         {
@@ -1092,11 +1146,18 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             }
         }
 
+        #region Private static helpers
+        
         //for multipliers ranging from .00001 to 10000000000
+
         //  Candidates are 1, 2, 2.5, and 5 * multiplier
+
         //    First candidate >starting interval is new interval 
+
         //  next candidate
+
         //next multiplier
+
         private static double GetRoundIncrement(double startValue)
         {
             int nPower; //power of 10. Range of -5 to 10 gives huge scale range.
@@ -1114,79 +1175,6 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             return candidate; //return the maximum
         }
 
-        private void CalcLargeOrSmallUnit(int dpi, int widthOnDevice, int numTics, double mapScale, double fBarUnitFactor,
-                                  out int pixelsPerTic, out double scaleBarUnitsPerTic)
-        {
-            if (_forceRecalc)
-            {
-                // revert to large scale unit
-                _barUnit = BarUnitLargeScale;
-                _barUnitFactor = _barUnitFactorLargeScale;
-                _barUnitName = _barUnitNameLargeScale;
-                _barUnitShortName = _barUnitShortNameLargeScale;
-                _forceRecalc = false;
-            }
-
-            CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactor, out pixelsPerTic, out scaleBarUnitsPerTic);
-
-            if (BarUnitLargeScale != BarUnitSmallScale)
-            {
-                if (_barUnitFactor == _barUnitFactorSmallScale)
-                {
-                    // currently on SmallScale units...
-                    // check how many scale bar units if using LargeScale unit
-                    CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactorLargeScale,
-                                            out int chkPixelsPerTick, out double chkScaleBarUnitsPerTic);
-
-                    // check if LargeScale bar length < 1 SmallScale unit
-                    if (NumTicks * chkScaleBarUnitsPerTic * _barUnitFactorLargeScale < _barUnitFactorSmallScale)
-                    {
-                        // switch to LargeScale units
-                        _barUnit = _barUnitLargeScale;
-                        _barUnitFactor = _barUnitFactorLargeScale;
-                        _barUnitName = _barUnitNameLargeScale;
-                        _barUnitShortName = _barUnitShortNameLargeScale;
-
-                        pixelsPerTic = chkPixelsPerTick;
-                        scaleBarUnitsPerTic = chkScaleBarUnitsPerTic;
-                    }
-                }
-                else
-                {
-                    // currently on LargeScale units...
-                    // check if LargeScale bar length >= 1 SmallScale unit (ie LargeScale units never exceed 1 SmallScale unit)
-                    if (NumTicks * scaleBarUnitsPerTic * _barUnitFactorLargeScale >= _barUnitFactorSmallScale)
-                    {
-                        // recalc for SmallScale unit
-                        CalcBarScale(dpi, widthOnDevice, numTics, mapScale, _barUnitFactorSmallScale,
-                                                out pixelsPerTic, out scaleBarUnitsPerTic);
-
-                        // switch to SmallScale units
-                        _barUnit = _barUnitSmallScale;
-                        _barUnitFactor = _barUnitFactorSmallScale;
-                        _barUnitName = _barUnitNameSmallScale;
-                        _barUnitShortName = _barUnitShortNameSmallScale;
-                    }
-                }
-            }
-        }
-
-        private void CalcBarScale(int dpi, int widthOnDevice, int numTics, double mapScale, double fBarUnitFactor,
-                                  out int pixelsPerTic, out double scaleBarUnitsPerTic)
-        {
-            int minPixelsPerTic = widthOnDevice / (numTics * 2);
-            double barScale = mapScale / fBarUnitFactor;
-            int pixelsPerInch = dpi;
-            double barUnitsPerPixel = barScale * GeoSpatialMath.MetersPerInch / pixelsPerInch;
-
-            //calculate the result
-            barUnitsPerPixel *= _webMercatorFactor;
-
-            scaleBarUnitsPerTic = minPixelsPerTic * barUnitsPerPixel;
-            scaleBarUnitsPerTic = GetRoundIncrement(scaleBarUnitsPerTic);
-            pixelsPerTic = (int)(scaleBarUnitsPerTic / barUnitsPerPixel);
-        }
-
         ///<summary>
         /// Keep only 5 (ScalePrecisionDigits) digits of precision for the scale and return the scale after formatted.
         ///</summary>
@@ -1202,6 +1190,13 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
                 roundedScale = (int)(scale + 0.5);
             return roundedScale;
         }
+
+        private static readonly StringFormat TopCenter =
+            new StringFormat
+            {
+                LineAlignment = StringAlignment.Near,
+                Alignment = StringAlignment.Center
+            };
 
         ///<summary>
         /// Return the precision for the segment text of the scale bar.
@@ -1221,7 +1216,7 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
             return precision;
         }
 
-        static private int MeasureDisplayStringWidthExact(Graphics graphics, string text,
+        private static int MeasureDisplayStringWidthExact(Graphics graphics, string text,
                                             Font font)
         {
             var ranges = new[] { new CharacterRange(0, text.Length) };

--- a/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
+++ b/SharpMap/Rendering/Decoration/ScaleBar/ScaleBar.cs
@@ -126,9 +126,9 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         /// <para>This is just the size of the decoration object, border settings are excluded</para>
         /// </summary>
         /// <param name="g">The graphics object</param>
-        /// <param name="map">The map</param>
+        /// <param name="map">The mapviewport</param>
         /// <returns>The size of the map decoration</returns>
-        protected override Size InternalSize(Graphics g, Map map)
+        protected override Size InternalSize(Graphics g, MapViewport map)
         {
             CalcScale((int)g.DpiX);
             double width = MarginLeft + MarginRight + DefaultWidth;
@@ -141,7 +141,7 @@ namespace SharpMap.Rendering.Decoration.ScaleBar
         /// </summary>
         /// <param name="g"></param>
         /// <param name="map"></param>
-        protected override void OnRender(Graphics g, Map map)
+        protected override void OnRender(Graphics g, MapViewport map)
         {
             var rectF = g.ClipBounds;
 

--- a/SharpMap/Utilities/GeoSpatialMath.cs
+++ b/SharpMap/Utilities/GeoSpatialMath.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using GeoAPI.Geometries;
 
 namespace SharpMap.Utilities
 {
@@ -32,6 +33,22 @@ namespace SharpMap.Utilities
         /// </summary>
         public const double MetersPerDegreeAtEquator = MetersPerMile * MilesPerDegreeAtEquator;
 
+        /// <summary>
+        /// Web Mercator SRID constant
+        /// </summary>
+        public const int WebMercatorSrid = 3857;
+        
+        /// <summary>
+        /// Web Mercator SRID constant
+        /// </summary>
+        public const double WebMercatorRadius = 6378137.0;
+        
+        /// <summary>
+        /// Web Mercator Domain as Envelope
+        /// </summary>
+        public static readonly Envelope WebMercatorEnv = new Envelope(-20037508.34,20037508.34,-20000000,20000000);
+
+        
         /// <summary>
         /// Calculate the distance between 2 points on the great circle
         /// </summary>

--- a/SharpMap/Utilities/Transform.cs
+++ b/SharpMap/Utilities/Transform.cs
@@ -15,8 +15,10 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
+using System;
 using System.Drawing;
 using GeoAPI.Geometries;
+using NetTopologySuite.Geometries.Utilities;
 
 namespace SharpMap.Utilities
 {
@@ -26,65 +28,169 @@ namespace SharpMap.Utilities
     public class Transform
     {
         /// <summary>
-        /// Transforms from image coordinates to world coordinate system (WCS).
-        /// NOTE: This method DOES NOT take the MapTransform property into account (use <see cref="Map.ImageToWorld(System.Drawing.PointF,bool)"/> instead)
+        /// Am abbreviated transform from world coordinate system (WCS) to image coordinates
+        /// for use ONLY when MapTransformRotation == 0
         /// </summary>
-        /// <param name="p">Point in image coordinate system</param>
-        /// <param name="map">Map reference</param>
-        /// <returns>Point in WCS</returns>
-        public static Coordinate MapToWorld(PointF p, MapViewport map)
+        /// <param name="coordinates">Coordinate array in WCS</param>
+        /// <param name="worldLeft">Minimum X value of non-rotated viewport in world coordinates</param>
+        /// <param name="worldTop">Maximum Y value of non-rotated viewport in world coordinates</param>
+        /// <param name="pixelWidth">Apparent width of pixel in world units</param>
+        /// <param name="pixelHeight">Apparent height of pixel in world units</param>
+        /// <returns>Point array in image coordinates</returns>
+        internal static PointF[] WorldToMap(Coordinate[] coordinates, double worldLeft, double worldTop,
+            double pixelWidth, double pixelHeight)
         {
-            if (map.Center.IsEmpty() || double.IsNaN(map.MapHeight))
+            // ONLY when MapTransFormRotation == 0
+            var points = new PointF[coordinates.Length];
+            for (var i = 0; i < coordinates.Length; i++)
             {
-                return new Coordinate(0, 0);
+                var coord = coordinates[i];
+                if (coord.IsEmpty() || double.IsNaN(coord.X) || double.IsNaN(coord.Y))
+                {
+                    points[i] = PointF.Empty;
+                }
+                else
+                {
+                    double x = (coord.X - worldLeft) / pixelWidth;
+                    double y = (worldTop - coord.Y) / pixelHeight;
+                    points[i] = new PointF((float) x, (float) y);
+                }
             }
-            var ul = new Coordinate(map.Center.X - map.Zoom * .5, map.Center.Y + map.MapHeight * .5);
-            return new Coordinate(ul.X + p.X * map.PixelWidth,
-                                  ul.Y - p.Y * map.PixelHeight);
+            return points;
+        }
+
+        /// <summary>
+        /// Full affine transformation from world coordinate system (WCS) to image coordinates taking into 
+        /// account Zoom, Pixel Width/Height, and MapTransformRotation. 
+        /// </summary>
+        /// <param name="coordinates">Coordinate array in WCS</param>
+        /// <param name="matrix">Appropriate affine transformation as defined by <see cref="WorldToMapMatrix"/></param>
+        /// <returns>Point array in image coordinates</returns>
+        public static PointF[] WorldToMap(Coordinate[] coordinates, AffineTransformation matrix)
+        {
+            var points = new PointF[coordinates.Length];
+            var transformed = new Coordinate();
+            for (var i = 0; i < coordinates.Length; i++)
+            {
+                matrix.Transform(coordinates[i], transformed);
+                points[i] = new PointF((float)transformed.X, (float)transformed.Y);
+            }
+            return points;
+        }
+
+        /// <summary>
+        /// Affine transformation defining complete transformation from world coordinate system (WCS) to image coordinates taking into 
+        /// account Zoom, Pixel Width/Height, and MapTransformRotation. Additionally, if <paramref name="careAboutTransform"/> = false,
+        /// the viewport rotation will be reverted at the end of the transformation, to be re-applied by Graphics object when rendering. 
+        /// </summary>
+        /// <param name="worldCenter">Map center in WCS</param>
+        /// <param name="pixelWidth">Width of pixel in world units</param>
+        /// <param name="pixelHeight">Height of pixel in world units</param>
+        /// <param name="mapTransformRotation">map rotation in degrees</param>
+        /// <param name="imageSize">Map Size when rendered</param>
+        /// <param name="careAboutTransform">True for coordinate calculations, False if Graphics object will apply MapTransform</param>
+        /// <returns>Affine Transformation</returns>
+        public static AffineTransformation WorldToMapMatrix(Coordinate worldCenter, 
+            double pixelWidth, double pixelHeight, float mapTransformRotation, Size imageSize,
+            bool careAboutTransform)
+        {
+            var rad = NetTopologySuite.Utilities.Degrees.ToRadians(mapTransformRotation);
+            var trans = new AffineTransformation();
+            trans.Compose(AffineTransformation.TranslationInstance(-worldCenter.X, -worldCenter.Y));
+            trans.Compose(AffineTransformation.RotationInstance(-rad));
+            trans.Compose(AffineTransformation.ScaleInstance(1 / pixelWidth, -1 / pixelHeight));
+            trans.Compose(AffineTransformation.TranslationInstance(imageSize.Width * 0.5, imageSize.Height * 0.5));
+
+            if (!careAboutTransform)
+            {
+                // if we DON'T care about transform (implies that rotation in image space WILL be performed by graphics
+                // object once drawing of ALL objects has been completed) then need to revert rotation (ie MapTransform).
+                trans.Compose(AffineTransformation.RotationInstance(-rad, imageSize.Width * 0.5, imageSize.Height * 0.5));
+            }
+            return trans;
+        }
+
+        /// <summary>
+        /// Am abbreviated transform from image coordinates to world coordinate system (WCS) 
+        /// for use ONLY when MapTransformRotation == 0
+        /// </summary>
+        /// <param name="points">Point array in image coordinates</param>
+        /// <param name="map">Map defining current view properties</param>
+        public static Coordinate[] MapToWorld(PointF[] points, Map map)
+        {
+            return MapToWorld(points, map.Center, map.Zoom, map.MapHeight, map.PixelWidth, map.PixelHeight);
+        }
+
+
+        /// <summary>
+        /// Am abbreviated transform from image coordinates to world coordinate system (WCS) 
+        /// for use ONLY when MapTransformRotation == 0
+        /// </summary>
+        /// <param name="points">Point array in image coordinates</param>
+        /// <param name="worldCenter">Map center in WCS</param>
+        /// <param name="mapZoom">current map zoom (width) in world units</param>
+        /// <param name="mapHeight">current map height in world units</param>
+        /// <param name="pixelWidth">Apparent width of pixel in world units</param>
+        /// <param name="pixelHeight">Apparent height of pixel in world units</param>
+        internal static Coordinate[] MapToWorld(PointF[] points, Coordinate worldCenter, double mapZoom,
+            double mapHeight, double pixelWidth, double pixelHeight)
+        {
+            var coords = new Coordinate[points.Length];
+            if (worldCenter.IsEmpty() || double.IsNaN(mapHeight))
+                for (var i = 0; i < points.Length; i++)
+                    coords[i] = new Coordinate(0, 0);
+            else
+            {
+                var ul = new Coordinate(worldCenter.X - mapZoom * .5,worldCenter.Y + mapHeight * .5);
+                for (var i = 0; i < points.Length; i++)
+                    coords[i] = new Coordinate(ul.X + points[i].X * pixelWidth,ul.Y - points[i].Y * pixelHeight);
+            }
+
+            return coords;
         }
 
         /// <summary>
         /// Transforms from world coordinate system (WCS) to image coordinates
-        /// NOTE: This method DOES NOT take the MapTransform property into account (use <see cref="Map.WorldToImage(GeoAPI.Geometries.Coordinate,bool)"/> instead)
+        /// NOTE: This method is only applicable when MapTransformRotation = 0.
         /// </summary>
         /// <param name="p">Point in WCS</param>
         /// <param name="map">Map reference</param>
         /// <returns>Point in image coordinates</returns>
-        public static PointF WorldtoMap(Coordinate p, Map map)
+        [Obsolete("Use WorldToMap(Coordinate[], Map)")]
+        public static PointF WorldToMap(Coordinate p, Map map)
         {
-            //if (map.MapTransform != null && !map.MapTransform.IsIdentity)
-            //	map.MapTransform.TransformPoints(new System.Drawing.PointF[] { p });
-            if (p.IsEmpty())
-                return PointF.Empty;
-
-            var result = new PointF();
-
-            var height = (map.Zoom * map.Size.Height) / map.Size.Width;
             var left = map.Center.X - map.Zoom * 0.5;
-            var top = map.Center.Y + height * 0.5 * map.PixelAspectRatio;
-            result.X = (float)((p.X - left) / map.PixelWidth);
-            result.Y = (float)((top - p.Y) / map.PixelHeight);
-            if (double.IsNaN(result.X) || double.IsNaN(result.Y))
-                result = PointF.Empty;
-            return result;
+            var top = map.Center.Y + map.MapHeight * 0.5;
+            var points = WorldToMap(new [] {p}, left, top, map.PixelWidth, map.PixelHeight);
+            return points[0];
         }
 
         /// <summary>
         /// Transforms from image coordinates to world coordinate system (WCS).
-        /// NOTE: This method DOES NOT take the MapTransform property into account (use <see cref="Map.ImageToWorld(System.Drawing.PointF,bool)"/> instead)
+        /// NOTE: This method is only applicable when MapTransformRotation = 0.
         /// </summary>
         /// <param name="p">Point in image coordinate system</param>
         /// <param name="map">Map reference</param>
         /// <returns>Point in WCS</returns>
+        [Obsolete("Use MapToWorld(PointF[], Map)")]
         public static Coordinate MapToWorld(PointF p, Map map)
         {
-            if (map.Center.IsEmpty() || double.IsNaN(map.MapHeight))
-            {
-                return new Coordinate(0, 0);
-            }
-            var ul = new Coordinate(map.Center.X - map.Zoom * .5, map.Center.Y + map.MapHeight * .5);
-            return new Coordinate(ul.X + p.X * map.PixelWidth,
-                                  ul.Y - p.Y * map.PixelHeight);
+            var coords = MapToWorld(new [] {p}, map);
+            return coords[0];
+        }
+        
+        /// <summary>
+        /// Transforms from image coordinates to world coordinate system (WCS).
+        /// NOTE: This method is only applicable when MapTransformRotation = 0.
+        /// </summary>
+        /// <param name="p">Point in image coordinate system</param>
+        /// <param name="map">Map reference</param>
+        /// <returns>Point in WCS</returns>
+        [Obsolete("Use MapToWorld(PointF[], MapViewport)")]
+        public static Coordinate MapToWorld(PointF p, MapViewport map)
+        {
+            var coords = MapToWorld(new [] {p}, map.Center, map.Zoom, map.MapHeight, map.PixelWidth, map.PixelHeight);
+            return coords[0];
         }
     }
 }

--- a/UnitTests/Data/Providers/DbTests.cs
+++ b/UnitTests/Data/Providers/DbTests.cs
@@ -160,7 +160,6 @@
         [NUnit.Framework.Test]
         public void Test99GetMap()
         {
-
             var m = new SharpMap.Map(new System.Drawing.Size(512, 1048));
             var p = GetProvider();
             //p.SRID = 4326;
@@ -168,11 +167,10 @@
             var l = new SharpMap.Layers.VectorLayer("SpDb", p);
             m.Layers.Add(l);
             m.ZoomToExtents();
-            var i = m.GetMap();
-            var path = System.IO.Path.Combine(
-                System.IO.Directory.GetCurrentDirectory(),
-                string.Format("SpatialDbProvider_{0}.png", ImplementationName));
-            i.Save(path, System.Drawing.Imaging.ImageFormat.Png);
+
+            var path = System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), $"SpatialDbProvider_{ImplementationName}.png");
+            using (var i = m.GetMap())
+                i.Save(path, System.Drawing.Imaging.ImageFormat.Png);
             System.Diagnostics.Trace.WriteLine(new System.Uri(path).LocalPath);
         }
 

--- a/UnitTests/Data/Providers/KmlProviderTests.cs
+++ b/UnitTests/Data/Providers/KmlProviderTests.cs
@@ -44,10 +44,8 @@ namespace UnitTests.Data.Providers
             m.ZoomToExtents();
             m.Zoom *= 1.1;
 
-            var img = m.GetMap();
-            img.Save("KmlProviderImage.png", ImageFormat.Png);
-
-
+            using (var img = m.GetMap())
+                img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "KmlProviderImage.png"), ImageFormat.Png);
         }
     }
 }

--- a/UnitTests/Data/Providers/SQLServer2008Tests.cs
+++ b/UnitTests/Data/Providers/SQLServer2008Tests.cs
@@ -261,7 +261,7 @@ namespace UnitTests.Data.Providers
             switch (providerMode)
             {
                 case SqlServerProviderMode.NativeSqlBytes:
-                    Assert.Ignore("Ignore SharpMap.Data.Providers.SqlSErver2008Ex");
+                    //Assert.Ignore("Ignore SharpMap.Data.Providers.SqlServer2008Ex");
 
                     if (spatialType == SqlServerSpatialObjectType.Geography)
                         // NB note forcing WGS84
@@ -543,9 +543,10 @@ namespace UnitTests.Data.Providers
             TimeSpan avgex = TimeSpan.FromTicks((long)measurementsex.Average(x => x.Ticks));
 
             // The SqlServer2008Ex provider should be faster:
-            // Update Nov 2018: apparently this is no longer the case. Multiple tests following recent updates have SqlServer2008 
-            // consistently outperforming SqlServer2008ex (100 - 3600 records). I'm not sure if this is due to improvments in later 
-            // releases of SqlServer, or perhaps WKB payload smaller than SqlBytes (even though requires database CPU for WKB conversion)
+            // Update Nov 2018: "should"....  highly dependent on client computer specs, and dataset characteristics
+            // may also have an affect in real-world usage (eg num records, OGC geom type, geom complexity).
+            // For the test dataset @ 100 records and also @ 3600 records on an AVERAGE computer, SqlServer2008 is
+            // consistently out-performing SqlServer2008Ex as follows:
             //    for local instance SqlExpress, SqlServer2008  is consistently 30% faster than SqlServer2008Ex
             //    for SqlServer on local database server, - I don't have one to test against
             //    for Azure SQL (50DTU limit, test peaking at 26DTU), SqlServer2008 is about 5% faster than SqlServer2008Ex

--- a/UnitTests/Data/Providers/ShapeFileProviderTests.cs
+++ b/UnitTests/Data/Providers/ShapeFileProviderTests.cs
@@ -163,9 +163,10 @@ namespace UnitTests.Data.Providers
 
             RepeatedRendering(map, shp.GetFeatureCount(), NumberOfRenderCycles, out _msVector);
 
-            var res = map.GetMap();
-            var path = System.IO.Path.ChangeExtension(GetTestDataFilePath("SPATIAL_F_SKARVMUFF.shp"), ".vector.png");
-            res.Save(path, System.Drawing.Imaging.ImageFormat.Png);
+            var path = System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "SPATIAL_F_SKARVMUFF.shp");
+            path = System.IO.Path.ChangeExtension(path, ".vector.png");
+            using (var res = map.GetMap())
+                res.Save(path, System.Drawing.Imaging.ImageFormat.Png);
             System.Diagnostics.Trace.WriteLine("\nResult saved at file://" + path.Replace('\\', '/'));
         }
 
@@ -194,9 +195,10 @@ namespace UnitTests.Data.Providers
             long tmp;
             RepeatedRendering(map, shp.GetFeatureCount(), 1, out tmp);
 
-            var res = map.GetMap();
-            var path = System.IO.Path.ChangeExtension(GetTestDataFilePath("SPATIAL_F_SKARVMUFF.shp"), "lineal.png");
-            res.Save(path, System.Drawing.Imaging.ImageFormat.Png);
+            var path = System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "SPATIAL_F_SKARVMUFF.shp");
+            path = System.IO.Path.ChangeExtension(path, "lineal.png");
+            using (var res = map.GetMap())
+                res.Save(path, System.Drawing.Imaging.ImageFormat.Png);
             System.Diagnostics.Trace.WriteLine("\nResult saved at file://" + path.Replace('\\', '/'));
         }
 

--- a/UnitTests/Layers/CoordinateTransformationTest.cs
+++ b/UnitTests/Layers/CoordinateTransformationTest.cs
@@ -34,7 +34,7 @@ namespace UnitTests.Layers
             m.ZoomToBox(box);
 
             using (var img = m.GetMap())
-                img.Save(System.IO.Path.Combine(System.IO.Path.GetTempPath(), _baseFileName + "NoTargetSrid.bmp"));
+                img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), _baseFileName + "NoTargetSrid.bmp"));
 
             // Test setting TargetSRID (should cause CoordinateTransformation to be updated) and generate maps with symmetrical 8-pointed star
             TestSrid(m, 4326, _gcsTolerance);
@@ -115,7 +115,7 @@ namespace UnitTests.Layers
 
             // visual check: symmetrical 8-pointed star
             using (var img = m.GetMap())
-                img.Save(System.IO.Path.Combine(System.IO.Path.GetTempPath(), _baseFileName + "_SRID_" + targetSrid + ".bmp"));
+                img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), _baseFileName + "_SRID_" + targetSrid + ".bmp"));
         }
 
         private void TestTrans(Map m, int targetSrid, double tolerance)
@@ -135,7 +135,7 @@ namespace UnitTests.Layers
 
             // visual check: symmetrical 8-pointed star
             using (var img = m.GetMap())
-                img.Save(System.IO.Path.Combine(System.IO.Path.GetTempPath(), _baseFileName + "_Trans_" + targetSrid + ".bmp"));
+                img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), _baseFileName + "_Trans_" + targetSrid + ".bmp"));
         }
 
         private void SetTargetSridAndZoomExtents(Map m, int targetSrid)

--- a/UnitTests/Layers/LabelLayerTest.cs
+++ b/UnitTests/Layers/LabelLayerTest.cs
@@ -77,7 +77,7 @@ namespace UnitTests.Layers
 
                 m.ZoomToExtents();
                 using (var mapImage = m.GetMap())
-                    mapImage.Save("MultiLineCenterAligned.png", ImageFormat.Png);
+                    mapImage.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "MultiLineCenterAligned.png"), ImageFormat.Png);
             }
         }
 

--- a/UnitTests/Layers/TileLayerIssues.cs
+++ b/UnitTests/Layers/TileLayerIssues.cs
@@ -34,9 +34,9 @@ namespace UnitTests.Layers
                 map.ZoomToBox(new Envelope(829384.331338522, 837200.785470394, 7068020.31417922, 7072526.73926545)
                             /*new Envelope(-239839.49199841652, 78451.759683380573, -37033.0152981899, 106723.52879865949)*/);
                 using (var image = map.GetMap())
-                {
-                    image.Save("TestIncompleteImage.png", ImageFormat.Png);
-                }
+                    image.Save(
+                        System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "TestIncompleteImage.png"),
+                        ImageFormat.Png);
             }
         }
     }

--- a/UnitTests/MapDecorationTest.cs
+++ b/UnitTests/MapDecorationTest.cs
@@ -14,12 +14,12 @@ namespace UnitTests
 {
     public class TestDecoration : MapDecoration
     {
-        protected override Size InternalSize(Graphics g, Map map)
+        protected override Size InternalSize(Graphics g, MapViewport map)
         {
             return new Size(50, 30);
         }
 
-        protected override void OnRender(Graphics g, Map map)
+        protected override void OnRender(Graphics g, MapViewport map)
         {
             g.FillRegion(new SolidBrush(OpacityColor(Color.Red)), g.Clip);
         }

--- a/UnitTests/MapDecorationTest.cs
+++ b/UnitTests/MapDecorationTest.cs
@@ -76,8 +76,9 @@ namespace UnitTests
                 NumTicks = 2,
                 Opacity = 1f
             });
-            var bmp = m.GetMap();
-            bmp.Save("TestMapDecorationTest.bmp");
+
+            using (var bmp = m.GetMap())
+                bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "TestMapDecorationTest.bmp"));
         }
 
     }

--- a/UnitTests/MapTest.cs
+++ b/UnitTests/MapTest.cs
@@ -396,62 +396,64 @@ namespace UnitTests
             Trace.WriteLine($"WorldToImageTransform_Benchmark {shapeFileName} {mapTransformRotation:000}deg MAP old: {oldTimesAvgMap}  MAP new: {newTimesAvgMap}");
             // allow a little bit of leeway
             Assert.LessOrEqual(newTimesAvgMap / oldTimesAvgMap,1.2,$"{shapeFileName}_{mapTransformRotation}deg_MAP" );
-           
-            // MapViewport Tests
-            var mvp = (MapViewport) map;
-            for (var i = 0; i < numTests; i++)
-            {
-                // old
-                sw.Reset();
-                sw.Start();
-                foreach (var geom in geoms)
-                {
-                    foreach (var p in geom.Coordinates)
-                    {
-                        var pt = mvp.WorldToImageOld(p, true);
-                        if (!mvp.MapTransformRotation.Equals(0f))
-                        {
-                            using (var transform = mvp.MapTransform)
-                            {
-                                var pts = new[] {pt};
-                                transform.TransformPoints(pts);
-                                pt = pts[0];
-                            }
-                        }
-                    }
-                }
-                sw.Stop();
-                oldTimesMvp.Add(sw.ElapsedMilliseconds);
-                
-                // new
-                sw.Reset();
-                sw.Start();
-                foreach (var geom in geoms)
-                {
-                    if (geom.Coordinates.Length == 0)
-                    {
-                        var pt = mvp.WorldToImage(geom.Coordinates[0], true);
-                    }
-                    else
-                    {
-                        var pts = mvp.WorldToImage(geom.Coordinates, true);
-                    }
-                }
 
-                sw.Stop();
-                newTimesMvp.Add(sw.ElapsedMilliseconds);
-            }
-            
-            oldTimesMvp.Sort();
-            newTimesMvp.Sort();
-            
-            var oldTimesAvgMvp = oldTimesMvp.Skip(2).Take(16).Average();
-            var newTimesAvgMvp = newTimesMvp.Skip(2).Take(16).Average();
-
-            
-            Trace.WriteLine($"WorldToImageTransform_Benchmark {shapeFileName} {mapTransformRotation:000}deg  MVP old: {oldTimesAvgMvp}  MVP new: {newTimesAvgMvp}");
-            // allow a little bit of leeway
-            Assert.LessOrEqual(newTimesAvgMvp/ oldTimesAvgMvp,1.2, $"{shapeFileName}_{mapTransformRotation}deg_MVP" );
+// NOTE: MapViewport Tests no longer relevant  due to redundant method WorldToImageOld being removed
+// Section commented out AFTER confirming test results
+//            // MapViewport Tests
+//            var mvp = (MapViewport) map;
+//            for (var i = 0; i < numTests; i++)
+//            {
+//                // old
+//                sw.Reset();
+//                sw.Start();
+//                foreach (var geom in geoms)
+//                {
+//                    foreach (var p in geom.Coordinates)
+//                    {
+//                        var pt = mvp.WorldToImageOld(p, true);
+//                        if (!mvp.MapTransformRotation.Equals(0f))
+//                        {
+//                            using (var transform = mvp.MapTransform)
+//                            {
+//                                var pts = new[] {pt};
+//                                transform.TransformPoints(pts);
+//                                pt = pts[0];
+//                            }
+//                        }
+//                    }
+//                }
+//                sw.Stop();
+//                oldTimesMvp.Add(sw.ElapsedMilliseconds);
+//                
+//                // new
+//                sw.Reset();
+//                sw.Start();
+//                foreach (var geom in geoms)
+//                {
+//                    if (geom.Coordinates.Length == 0)
+//                    {
+//                        var pt = mvp.WorldToImage(geom.Coordinates[0], true);
+//                    }
+//                    else
+//                    {
+//                        var pts = mvp.WorldToImage(geom.Coordinates, true);
+//                    }
+//                }
+//
+//                sw.Stop();
+//                newTimesMvp.Add(sw.ElapsedMilliseconds);
+//            }
+//            
+//            oldTimesMvp.Sort();
+//            newTimesMvp.Sort();
+//            
+//            var oldTimesAvgMvp = oldTimesMvp.Skip(2).Take(16).Average();
+//            var newTimesAvgMvp = newTimesMvp.Skip(2).Take(16).Average();
+//
+//            
+//            Trace.WriteLine($"WorldToImageTransform_Benchmark {shapeFileName} {mapTransformRotation:000}deg  MVP old: {oldTimesAvgMvp}  MVP new: {newTimesAvgMvp}");
+//            // allow a little bit of leeway
+//            Assert.LessOrEqual(newTimesAvgMvp/ oldTimesAvgMvp,1.2, $"{shapeFileName}_{mapTransformRotation}deg_MVP" );
 
             map.Dispose();
         }

--- a/UnitTests/MapTest.cs
+++ b/UnitTests/MapTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.Eventing.Reader;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
@@ -12,8 +11,6 @@ using NUnit.Framework;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.IO;
-using NetTopologySuite.Operation.Polygonize;
-using NUnit.Framework.Constraints;
 using SharpMap;
 using SharpMap.Data.Providers;
 using Geometry = GeoAPI.Geometries.IGeometry;

--- a/UnitTests/MapTest.cs
+++ b/UnitTests/MapTest.cs
@@ -418,9 +418,9 @@ namespace UnitTests
 
             map.ZoomToBox(lineString.EnvelopeInternal);
 
-            string fn = $"MapRotation_{deg:000}_{map.Zoom:0}_{map.MapScale:0}.bmp";
+            string fn = $"MapRotation_{deg:000}_{map.Zoom:0}_{map.MapScale:0}.png";
             using (var img = map.GetMap(96))
-                img.Save(fn,System.Drawing.Imaging.ImageFormat.Bmp);
+                img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), fn),System.Drawing.Imaging.ImageFormat.Png);
 
             map.Dispose();
         }
@@ -582,7 +582,7 @@ namespace UnitTests
                 var fn =
                     $"ZoomToBox_{mapSizeWidth}x{mapSizeHeight}_{degrees:0}deg_bbox_{env.Width}x{env.Height}_old.png";
                 using (var img = map.GetMap(96))
-                    img.Save(fn, System.Drawing.Imaging.ImageFormat.Bmp);
+                    img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), fn), System.Drawing.Imaging.ImageFormat.Bmp);
 
                 // reset view
                 map.Center = new Coordinate(0, 0);
@@ -591,7 +591,7 @@ namespace UnitTests
 //                map.ZoomToBox(env, true);
 //                fn = $"ZoomToBox_{mapSizeWidth}x{mapSizeHeight}_{degrees:0}deg_bbox_{env.Width}x{env.Height}_new.png";
 //                using (var img = map.GetMap(96))
-//                    img.Save(fn, System.Drawing.Imaging.ImageFormat.Bmp);
+//                    img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), fn), System.Drawing.Imaging.ImageFormat.Bmp);
             }
 
             map.Dispose();

--- a/UnitTests/Rendering/Decoration/ScaleBar/ScaleBarTests.cs
+++ b/UnitTests/Rendering/Decoration/ScaleBar/ScaleBarTests.cs
@@ -26,12 +26,10 @@ namespace UnitTests.Rendering.Decoration.ScaleBar
         //private readonly List<int> _testLatitudes = new List<int> {0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85};
         private readonly List<int> _testLatitudes = new List<int> {0, 10, 20, 30, 40, 50, 60, 70, 80};
 
-
         [TestFixtureSetUp]
         public void SetupMap()
         {
-            System.IO.Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "SharpMap"));
-            System.IO.Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "BruTileCache", "Osm"));
+            //System.IO.Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "BruTileCache", "Osm"));
 
             var files = System.IO.Directory.GetFiles(Path.Combine(Path.GetTempPath(), "SharpMap"));
             foreach (var file in files)
@@ -70,16 +68,16 @@ namespace UnitTests.Rendering.Decoration.ScaleBar
 
             _map.Layers.Add(lyr);
 
-            // Add bru-tile map background
-            var cacheFolder = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "BruTileCache", "Osm");
-            var lyrBruTile = new TileLayer(
-                BruTile.Predefined.KnownTileSources.Create(BruTile.Predefined.KnownTileSource.OpenStreetMap),
-                "Tiles", Color.Transparent, true, cacheFolder)
-            {
-                SRID = 3857,
-                TargetSRID = _map.SRID
-            };
-            _map.BackgroundLayer.Add(lyrBruTile);
+            // Add bru-tile map background 
+//            var cacheFolder = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "BruTileCache", "Osm");
+//            var lyrBruTile = new TileLayer(
+//                BruTile.Predefined.KnownTileSources.Create(BruTile.Predefined.KnownTileSource.OpenStreetMap),
+//                "Tiles", Color.Transparent, true, cacheFolder)
+//            {
+//                SRID = 3857,
+//                TargetSRID = _map.SRID
+//            };
+//            _map.BackgroundLayer.Add(lyrBruTile);
 
             var scaleBar = new SharpMap.Rendering.Decoration.ScaleBar.ScaleBar()
             {
@@ -1263,12 +1261,10 @@ namespace UnitTests.Rendering.Decoration.ScaleBar
             _map.ZoomToBox(box);
 
             // generate image
-            var img = _map.GetMap();
             var strLat = (centerLat.HasValue) ? $"Lat_{centerLat:D2}" : "AllPoints";
-            img.Save(
-                Path.Combine(Path.GetTempPath(), "SharpMap",
-                    $"ScaleBarTest_{srDescr}_{strLat}_Interval_{interval:D5}.bmp"),
-                System.Drawing.Imaging.ImageFormat.Bmp);
+            using (var img = _map.GetMap())
+                img.Save(Path.Combine(UnitTestsFixture.GetImageDirectory(this), $"ScaleBarTest_{srDescr}_{strLat}_Interval_{interval:D5}.png"),
+                    System.Drawing.Imaging.ImageFormat.Png);
         }
     }
 }

--- a/UnitTests/Rendering/Decoration/ScaleBar/ScaleBarTests.cs
+++ b/UnitTests/Rendering/Decoration/ScaleBar/ScaleBarTests.cs
@@ -31,9 +31,9 @@ namespace UnitTests.Rendering.Decoration.ScaleBar
         {
             //System.IO.Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "BruTileCache", "Osm"));
 
-            var files = System.IO.Directory.GetFiles(Path.Combine(Path.GetTempPath(), "SharpMap"));
-            foreach (var file in files)
-                System.IO.File.Delete(file);
+//            var files = System.IO.Directory.GetFiles(Path.Combine(Path.GetTempPath(), "SharpMap"));
+//            foreach (var file in files)
+//                System.IO.File.Delete(file);
 
             var gss = new NtsGeometryServices();
             var css = new SharpMap.CoordinateSystems.CoordinateSystemServices(

--- a/UnitTests/Rendering/GroupStyle/GroupStyleTests.cs
+++ b/UnitTests/Rendering/GroupStyle/GroupStyleTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System.Drawing;
+using System.Drawing.Imaging;
 using SharpMap.Layers;
 using SharpMap;
 
@@ -70,7 +71,7 @@ namespace UnitTests.Rendering.GroupStyle
             m.Layers.Add(vLay);
             var img = m.GetMap();
 
-            img.Save(@"c:\\temp\ren.png");
+            img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "render.png"), ImageFormat.Png);
 
             Bitmap bmp = img as Bitmap;
             Color c1 = bmp.GetPixel(5, 5);

--- a/UnitTests/Rendering/Symbolizer/LineSymbolizerTest.cs
+++ b/UnitTests/Rendering/Symbolizer/LineSymbolizerTest.cs
@@ -36,7 +36,7 @@
             var bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering old method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("NDSRoads1.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "NDSRoads1.bmp"));
 
 
             var cls = new SharpMap.Rendering.Symbolizer.CachedLineSymbolizer();
@@ -48,7 +48,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("NDSRoads2.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "NDSRoads2.bmp"));
 
         }
 
@@ -85,7 +85,7 @@
             var bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads1.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads1.bmp"));
 
             cls.LineSymbolizeHandlers[1] = new SharpMap.Rendering.Symbolizer.WarpedLineSymbolizeHander
                                                {
@@ -100,7 +100,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads2-0.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads2-0.bmp"));
 
             cls.LineSymbolizeHandlers[1] = new SharpMap.Rendering.Symbolizer.WarpedLineSymbolizeHander
             {
@@ -116,7 +116,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads2-1.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this),"AurichRoads2-1.bmp"));
             cls.LineSymbolizeHandlers[1] = new SharpMap.Rendering.Symbolizer.WarpedLineSymbolizeHander
             {
                 Pattern =
@@ -131,7 +131,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads2-2.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads2-2.bmp"));
 
             cls.LineSymbolizeHandlers[1] = new SharpMap.Rendering.Symbolizer.WarpedLineSymbolizeHander
             {
@@ -147,7 +147,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads2-3.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads2-3.bmp"));
 
 
             //cls.LineSymbolizeHandlers[0] = cls.LineSymbolizeHandlers[1];
@@ -162,7 +162,7 @@
             bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads3.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads3.bmp"));
         }
 
         [NUnit.Framework.Test]
@@ -185,7 +185,7 @@
             var bmp = m.GetMap();
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method: {0}ms", sw.ElapsedMilliseconds));
-            bmp.Save("AurichRoads1Theme.bmp");
+            bmp.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "AurichRoads1Theme.bmp"));
         }
 
         internal class ClsTheme : SharpMap.Rendering.Thematics.ITheme

--- a/UnitTests/Rendering/Symbolizer/PointSymbolizerTest.cs
+++ b/UnitTests/Rendering/Symbolizer/PointSymbolizerTest.cs
@@ -24,17 +24,17 @@ namespace UnitTests.Rendering.Symbolizer
             
             map.Layers.Add(layer);
             map.ZoomToExtents();
-            map.GetMap().Save("CharacterPointSymbolizer1.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "CharacterPointSymbolizer1.bmp"));
 
             cps.Rotation = -30;
             cps.Offset = new System.Drawing.PointF(4, 4);
-            map.GetMap().Save("CharacterPointSymbolizer2.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "CharacterPointSymbolizer2.bmp"));
 
             cps.Font = new System.Drawing.Font("Arial", 12);
             cps.Text = "ABC";
             cps.Offset = System.Drawing.PointF.Empty;
             cps.Rotation = -90;
-            map.GetMap().Save("CharacterPointSymbolizer3.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "CharacterPointSymbolizer3.bmp"));
         }
 
 
@@ -53,14 +53,14 @@ namespace UnitTests.Rendering.Symbolizer
             var map = new SharpMap.Map(new System.Drawing.Size(720, 360));
             map.Layers.Add(layer);
             map.ZoomToExtents();
-            map.GetMap().Save("PathPointSymbolizer1.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PathPointSymbolizer1.bmp"));
 
             pps.Rotation = -30;
-            map.GetMap().Save("PathPointSymbolizer2.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PathPointSymbolizer2.bmp"));
 
             pps.Rotation = 0f;
             pps.Offset = new System.Drawing.PointF(4, 4);
-            map.GetMap().Save("PathPointSymbolizer3.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PathPointSymbolizer3.bmp"));
 
             var gpTriangle1 = new System.Drawing.Drawing2D.GraphicsPath();
             gpTriangle1.AddPolygon(new [] { new System.Drawing.Point(0, 0), new System.Drawing.Point(5, 10), new System.Drawing.Point(10, 0), new System.Drawing.Point(0, 0), });
@@ -93,9 +93,9 @@ namespace UnitTests.Rendering.Symbolizer
                                                         }){ Rotation = 45 };
 
             layer.Style.PointSymbolizer = pps;
-            map.GetMap().Save("PathPointSymbolizer4.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PathPointSymbolizer4.bmp"));
             pps.Rotation = 180;
-            map.GetMap().Save("PathPointSymbolizer5.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PathPointSymbolizer5.bmp"));
 
         }
 
@@ -118,10 +118,10 @@ namespace UnitTests.Rendering.Symbolizer
             var map = new SharpMap.Map(new System.Drawing.Size(720, 360));
             map.Layers.Add(layer);
             map.ZoomToExtents();
-            map.GetMap().Save("RasterPointSymbolizer1.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "RasterPointSymbolizer1.bmp"));
 
             rps.Rotation = 45;
-            map.GetMap().Save("RasterPointSymbolizer2.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "RasterPointSymbolizer2.bmp"));
             rps.Rotation = 0;
 
             var cps = new SharpMap.Rendering.Symbolizer.CharacterPointSymbolizer
@@ -140,7 +140,7 @@ namespace UnitTests.Rendering.Symbolizer
             layer.Style.PointSymbolizer = lps;
             map.Layers.Add(layer);
             map.ZoomToExtents();
-            map.GetMap().Save("RasterPointSymbolizer3.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "RasterPointSymbolizer3.bmp"));
         }
 
         [NUnit.Framework.Test]
@@ -170,7 +170,7 @@ namespace UnitTests.Rendering.Symbolizer
             var map = new SharpMap.Map(new System.Drawing.Size(720, 360));
             map.Layers.Add(layer);
             map.ZoomToExtents();
-            map.GetMap().Save("ListPointSymbolizer1.bmp");
+            map.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "ListPointSymbolizer1.bmp"));
         }
     }
 }

--- a/UnitTests/Rendering/Symbolizer/PolygonSymbolizerTest.cs
+++ b/UnitTests/Rendering/Symbolizer/PolygonSymbolizerTest.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Rendering.Symbolizer
             
             sw.Start();
             img = m.GetMap();
-            img.Save("PolygonSymbolizer-1.bmp", System.Drawing.Imaging.ImageFormat.Bmp);
+            img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "PolygonSymbolizer-1.bmp"), System.Drawing.Imaging.ImageFormat.Bmp);
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method:{0}ms", sw.ElapsedMilliseconds));
 
@@ -70,7 +70,7 @@ namespace UnitTests.Rendering.Symbolizer
 
             sw.Reset(); sw.Start();
             img = m.GetMap();
-            img.Save("PolygonSymbolizer-2.bmp", System.Drawing.Imaging.ImageFormat.Bmp);
+            img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this),"PolygonSymbolizer-2.bmp"), System.Drawing.Imaging.ImageFormat.Bmp);
             sw.Stop();
             System.Diagnostics.Trace.WriteLine(string.Format("Rendering new method:{0}ms", sw.ElapsedMilliseconds));
         

--- a/UnitTests/Rendering/Symbolizer/RasterPointSymbolizerTest.cs
+++ b/UnitTests/Rendering/Symbolizer/RasterPointSymbolizerTest.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Rendering.Symbolizer
             var m = CreateMap();
             m.ZoomToExtents();
             var img = m.GetMap();
-            img.Save("RasterPointSymbolizer.bmp", System.Drawing.Imaging.ImageFormat.Bmp);
+            img.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this),"RasterPointSymbolizer.png"), System.Drawing.Imaging.ImageFormat.Png);
         }
 
         private SharpMap.Map CreateMap()

--- a/UnitTests/Serialization/MapTest.cs
+++ b/UnitTests/Serialization/MapTest.cs
@@ -69,7 +69,7 @@ namespace UnitTests.Serialization
 
 
 
-        [Test, Description("MapQuest base map, OSM of Aurich, randomly styled")]
+        [Test, Description("BingHybridStaging base map, OSM of Aurich, randomly styled"), Ignore("Need to fix BruTile serialization")]
         public void TestMap2()
         {
             var m = new Map(_mapSize);

--- a/UnitTests/Serialization/MapTest.cs
+++ b/UnitTests/Serialization/MapTest.cs
@@ -63,8 +63,8 @@ namespace UnitTests.Serialization
             Assert.AreEqual(m.SRID, mD.SRID);
             Assert.AreEqual(m.Zoom, mD.Zoom);
 
-            Assert.DoesNotThrow(() => m.GetMap().Save(name + "-S.bmp"));
-            Assert.DoesNotThrow(() => mD.GetMap().Save(name + "-D.bmp"));
+            Assert.DoesNotThrow(() => m.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(new MapTest()), name + "-S.bmp")));
+            Assert.DoesNotThrow(() => mD.GetMap().Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(new MapTest()), name + "-D.bmp")));
         }
 
 

--- a/UnitTests/Serialization/MapTest.cs
+++ b/UnitTests/Serialization/MapTest.cs
@@ -73,7 +73,7 @@ namespace UnitTests.Serialization
         public void TestMap2()
         {
             var m = new Map(_mapSize);
-            m.BackgroundLayer.Add(new TileLayer(KnownTileSources.Create(KnownTileSource.MapQuest), "MapQuest"));
+            m.BackgroundLayer.Add(new TileLayer(KnownTileSources.Create(KnownTileSource.BingHybridStaging), "BingHybridStaging"));
             
             string cn = $"Data Source={Path.Combine("TestData", "osm_aurich.sqlite")};";
             

--- a/UnitTests/Serialization/SerializationTests.cs
+++ b/UnitTests/Serialization/SerializationTests.cs
@@ -16,6 +16,7 @@ using UnitTests.Serialization;
 
 namespace BruTile.Serialization.Tests
 {
+    [Category("BruTile"), Ignore("Fix first")]
     public class SerializationTests
     {
         [Test]

--- a/UnitTests/TestData/CreatingData.cs
+++ b/UnitTests/TestData/CreatingData.cs
@@ -183,8 +183,8 @@
             var gl = new SharpMap.Layers.VectorLayer("GeometryLayer", gp);
             map.Layers.Add(gl);
             map.ZoomToExtents();
-            var mapimage = map.GetMap();
-            mapimage.Save("ellipse.png", System.Drawing.Imaging.ImageFormat.Png);
+            using (var mapImage = map.GetMap())
+                mapImage.Save(System.IO.Path.Combine(UnitTestsFixture.GetImageDirectory(this), "ellipse.png"), System.Drawing.Imaging.ImageFormat.Png);
         }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -59,6 +59,14 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup Condition=" '$(Configuration)' != 'ReleaseLinux' ">
+    <!--<Reference Include="Microsoft.SqlServer.Types, Version=13.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />-->
+    <Reference Include="Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Programme\Microsoft SQL Server\100\SDK\Assemblies\Microsoft.SqlServer.Types.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="BruTile, Version=0.18.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\BruTile.0.18.1\lib\net40\BruTile.dll</HintPath>
@@ -87,7 +95,6 @@
       <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net40-client\GeoAPI.CoordinateSystems.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.SqlServer.Types, Version=13.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.2.2.7\lib\net40\Mono.Security.dll</HintPath>
       <Private>True</Private>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -60,15 +60,15 @@
   </Target>
   -->
   <ItemGroup>
-    <Reference Include="BruTile, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BruTile, Version=0.18.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\BruTile.0.18.1\lib\net40\BruTile.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="BruTile.Desktop, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BruTile.Desktop, Version=0.18.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\BruTile.Desktop.0.18.1\lib\net40\BruTile.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="BruTile.MbTiles, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BruTile.MbTiles, Version=0.18.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\BruTile.Desktop.0.18.1\lib\net40\BruTile.MbTiles.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -128,8 +128,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.SQLite, Version=1.0.109.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+    <Reference Include="System.Data.SQLite, Version=1.0.109.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.109.1\lib\net451\System.Data.SQLite.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -365,8 +366,10 @@
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Aktivieren Sie die Wiederherstellung von NuGet-Paketen, um die fehlende Datei herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\GDAL.Native.1.11.1\build\net40\GDAL.Native.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GDAL.Native.1.11.1\build\net40\GDAL.Native.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.94.0\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.94.0\build\net451\System.Data.SQLite.Core.targets'))" />
     <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.109.1\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.109.1\build\net451\System.Data.SQLite.Core.targets'))" />
   </Target>
   <Import Project="..\packages\GDAL.Native.1.11.1\build\net40\GDAL.Native.targets" Condition="Exists('..\packages\GDAL.Native.1.11.1\build\net40\GDAL.Native.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.94.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.94.0\build\net451\System.Data.SQLite.Core.targets')" />
   <Import Project="..\packages\System.Data.SQLite.Core.1.0.109.1\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.109.1\build\net451\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/UnitTests/UnitTestsFixture.cs
+++ b/UnitTests/UnitTestsFixture.cs
@@ -4,7 +4,8 @@
     public class UnitTestsFixture
     {
         private System.Diagnostics.Stopwatch _stopWatch;
-
+        private const string ImageBase = "Images"; 
+        
         [NUnit.Framework.SetUp]
         public void RunBeforeAnyTests()
         {
@@ -31,6 +32,14 @@
             _stopWatch.Stop();
             System.Diagnostics.Trace.WriteLine(
                 string.Format("All tests accomplished in {0}ms", _stopWatch.ElapsedMilliseconds));
+        }
+
+        internal static string GetImageDirectory(object T)
+        {
+            var imgPath = System.IO.Path.Combine($"{ImageBase}\\{T.GetType().FullName}");
+            if (!System.IO.Directory.Exists(imgPath))
+                System.IO.Directory.CreateDirectory(imgPath);
+            return imgPath;
         }
     }
 }

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BruTile" version="0.18.1" targetFramework="net40" />
-  <package id="BruTile.Desktop" version="0.18.1" targetFramework="net40" />
+  <package id="BruTile" version="0.18.1" targetFramework="net452" />
+  <package id="BruTile.Desktop" version="0.18.1" targetFramework="net452" />
   <package id="GDAL" version="1.11.1" targetFramework="net40" />
   <package id="GDAL.Native" version="1.11.1" targetFramework="net40" />
   <package id="GeoAPI" version="1.7.5" targetFramework="net40" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -23,5 +23,6 @@
   <package id="Rx-Linq" version="2.2.4" targetFramework="net403" />
   <package id="Rx-Main" version="2.2.4" targetFramework="net403" />
   <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net403" />
+  <package id="System.Data.SQLite.Core" version="1.0.94.0" targetFramework="net452" />
   <package id="System.Data.SQLite.Core" version="1.0.109.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
PR to address issues getting correct viewport dimensions in **rotated** world view (as a pre-cursor for Graticule MapDecoration). 

- Standardize `WorldToImage` and `ImageToWorld` methods across `map`, `mapviewport`, and `GeoApiEx`, and over-load to work with arrays rather than individual coordinates. This has resulted in significant performance improvements when rendering geometries based upon point collections (eg linestring, polygon) for both rotated **and** non-rotated maps

- Model `MapTransform` field in `map` class on changes previously made to `MapViewport` (ie store matrix parameters, getter instantiates new matrix from parameters).

- `MapDecorations` now render from `MapViewport` rather than `Map`

- update field and method summaries in `Map` class to remove confusion between 
`Zoom` and `MapWidth`, and also in `MapDecoration` to clarify re-setting of `MapTransform` for rendering.

- Fix `MapBox` zoom for rotated maps, and simplify pan operations

- Unit Tests to validate changes, including standardize image output to facilitate associating tests with images and vice versa
