### PR TITLE
Resolve SqlServer.Types dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,7 @@ I[V|v][V|v]*/
 I[V|v][V|v]*.*
 *I[V|v][V|v]/
 *I[V|v][V|v].*
-/SharpMap/SharpMap.png
+
+# Microsoft.SqlServer.Types NuGet files
+**/SqlServerTypes/Loader.cs
+**/SqlServerTypes/readme.htm

--- a/Examples/WinFormSamples/FormMapBox.cs
+++ b/Examples/WinFormSamples/FormMapBox.cs
@@ -274,11 +274,8 @@ namespace WinFormSamples
                         {
                             mapBox1.Refresh();
 
-                            MessageBox.Show("Requires SqlServer connection string to be defined (Project / Settings)\n\n" + 
-                                "Also, if project folder SqlServerTypes\\x64 and \\x86 are empty, then force reinstall of NuGet package:\n\n" +
-                                "PM> Update-Package Microsoft.SqlServer.Types -ProjectName Examples\\WinFormSamples -reinstall -ignoreDependencies","Sql Server",
-                                MessageBoxButtons.OK,MessageBoxIcon.Information);
-
+                            MessageBox.Show("Requires SqlServer connection string to be defined (Project / Settings)", 
+                                "Sql Server", MessageBoxButtons.OK,MessageBoxIcon.Information);
                             return;
                         }
                         // now show SqlServer dialog
@@ -320,8 +317,11 @@ namespace WinFormSamples
             {
                 MessageBox.Show(this, ex.Message, "Error");
             }
-            Cursor = Cursors.Default;
-            mapBox1.Cursor = mic;
+            finally
+            {
+                Cursor = Cursors.Default;
+                mapBox1.Cursor = mic;
+            }
         }
 
         private void mapImage_ActiveToolChanged(MapBox.Tools tool)

--- a/Examples/WinFormSamples/Samples/FormSqlServerOpts.cs
+++ b/Examples/WinFormSamples/Samples/FormSqlServerOpts.cs
@@ -25,8 +25,8 @@ namespace WinFormSamples.Samples
 
         protected override void OnLoad(EventArgs e)
         {
-            // required for NuGet package Microsoft.SqlServer.Types
-            SqlServerTypes.Utilities.LoadNativeAssemblies(AppDomain.CurrentDomain.BaseDirectory);
+            // NO LONGER REQUIRED (performed internally by SharpMap.SqlServerSpatialObjects)
+            //SqlServerTypes.Utilities.LoadNativeAssemblies(AppDomain.CurrentDomain.BaseDirectory);
 
             SqlServerSample.InitialiseTables(ConnectionString);
 

--- a/Examples/WinFormSamples/WinFormSamples.csproj
+++ b/Examples/WinFormSamples/WinFormSamples.csproj
@@ -89,9 +89,6 @@
     <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.7\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.SqlServer.Types.14.0.1016.290\lib\net40\Microsoft.SqlServer.Types.dll</HintPath>
-    </Reference>
     <Reference Include="NetTopologySuite, Version=1.15.1.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NetTopologySuite.Core.1.15.1\lib\net40-client\NetTopologySuite.dll</HintPath>
     </Reference>
@@ -183,20 +180,6 @@
     <Compile Include="Samples\SqlServerSample.cs" />
     <Compile Include="SampleTool.cs" />
     <Compile Include="SharpMapTileSource.cs" />
-    <Compile Include="SqlServerTypes\Loader.cs" />
-    <Content Include="SqlServerTypes\readme.htm" />
-    <Content Include="SqlServerTypes\x64\msvcr120.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SqlServerTypes\x64\SqlServerSpatial140.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SqlServerTypes\x86\msvcr120.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SqlServerTypes\x86\SqlServerSpatial140.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <EmbeddedResource Include="Magnifier.cur" />
     <EmbeddedResource Include="Samples\FormSqlServerOpts.resx">
       <DependentUpon>FormSqlServerOpts.cs</DependentUpon>

--- a/Examples/WinFormSamples/packages.config
+++ b/Examples/WinFormSamples/packages.config
@@ -11,7 +11,6 @@
   <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net40" requireReinstallation="true" />
   <package id="GeoAPI.Core" version="1.7.5" targetFramework="net40" requireReinstallation="true" />
   <package id="log4net" version="2.0.7" targetFramework="net40" requireReinstallation="true" />
-  <package id="Microsoft.SqlServer.Types" version="14.0.1016.290" targetFramework="net45" />
   <package id="NetTopologySuite" version="1.15.1" targetFramework="net40" />
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.1" targetFramework="net40" requireReinstallation="true" />
   <package id="NetTopologySuite.Core" version="1.15.1" targetFramework="net40" requireReinstallation="true" />

--- a/SharpMap.SqlServerSpatialObjects/Converters/SqlServer2008SpatialObjects/SqlGeographyConverter.cs
+++ b/SharpMap.SqlServerSpatialObjects/Converters/SqlServer2008SpatialObjects/SqlGeographyConverter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using GeoAPI.Geometries;
 using Microsoft.SqlServer.Types;
+using SharpMap.Data.Providers;
 using SMGeometry = GeoAPI.Geometries.IGeometry;
 using SMGeometryType = GeoAPI.Geometries.OgcGeometryType;
 using SMPoint = GeoAPI.Geometries.IPoint;
@@ -67,6 +68,11 @@ namespace SharpMap.Converters.SqlServer2008SpatialObjects
         // sys.spatial_reference_systems table corresponding to the SRID in which the instance is defined
         public static double ReduceTolerance = 1d;
 
+        static SqlGeographyConverter()
+        {
+            SqlServer2008Ex.LoadSqlServerTypes();
+        }
+        
         public static SqlGeography ToSqlGeography(SMGeometry smGeometry)
         {
             SqlGeographyBuilder builder = new SqlGeographyBuilder();

--- a/SharpMap.SqlServerSpatialObjects/Converters/SqlServer2008SpatialObjects/SqlGeometryConverter.cs
+++ b/SharpMap.SqlServerSpatialObjects/Converters/SqlServer2008SpatialObjects/SqlGeometryConverter.cs
@@ -3,7 +3,7 @@
 /*
  *  The attached / following is part of SharpMap.SqlServerSpatialObjects.
  *  
- *  SharpMap.SqlServerSpatialObjects is free software © 2010 Ingenieurgruppe IVV GmbH & Co. KG, 
+ *  SharpMap.SqlServerSpatialObjects is free software ï¿½ 2010 Ingenieurgruppe IVV GmbH & Co. KG, 
  *  www.ivv-aachen.de; you can redistribute it and/or modify it under the terms 
  *  of the current GNU Lesser General Public License (LGPL) as published by and 
  *  available from the Free Software Foundation, Inc., 
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using GeoAPI.Geometries;
 using Microsoft.SqlServer.Types;
+using SharpMap.Data.Providers;
 using SMGeometry = GeoAPI.Geometries.IGeometry;
 using SMGeometryType = GeoAPI.Geometries.OgcGeometryType;
 using SMPoint = GeoAPI.Geometries.IPoint;
@@ -84,7 +85,12 @@ namespace SharpMap.Converters.SqlServer2008SpatialObjects
         private static readonly GeoAPI.IGeometryServices Services = GeoAPI.GeometryServiceProvider.Instance;
 
         public static double ReduceTolerance = 1d;
-
+        
+        static  SqlGeometryConverter()
+        {
+            SqlServer2008Ex.LoadSqlServerTypes();    
+        }
+        
         public static SqlGeometry ToSqlGeometry(SMGeometry smGeometry)
         {
             SqlGeometryBuilder builder = new SqlGeometryBuilder();

--- a/SharpMap.SqlServerSpatialObjects/Data/Providers/SqlServer2008Ex.cs
+++ b/SharpMap.SqlServerSpatialObjects/Data/Providers/SqlServer2008Ex.cs
@@ -21,7 +21,6 @@ using SharpMap.Converters.SqlServer2008SpatialObjects;
 using System;
 using System.Collections.ObjectModel;
 using System.Data.SqlClient;
-using System.Globalization;
 using System.Text;
 using BoundingBox = GeoAPI.Geometries.Envelope;
 using Geometry = GeoAPI.Geometries.IGeometry;
@@ -48,6 +47,36 @@ namespace SharpMap.Data.Providers
     {
         static readonly ILog _logger = LogManager.GetLogger(typeof(SqlServer2008Ex));
 
+        private static bool _isSqlTypesLoaded;
+        private static readonly object _loadLock = new object();
+        
+        /// <summary>
+        /// Ensure SqlServerTypes (x32 or x64) are loaded at runtime
+        /// </summary>
+        static  SqlServer2008Ex()
+        {
+            if (!_isSqlTypesLoaded)
+                lock(_loadLock)
+                    if (!_isSqlTypesLoaded)
+                    {
+                        try
+                        {
+                            SqlServerTypes.Utilities.LoadNativeAssemblies(AppDomain.CurrentDomain.BaseDirectory);
+                            _isSqlTypesLoaded = true;
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine(e);
+                            throw;
+                        }
+                    }
+        }
+
+        /// <summary>
+        /// placeholder method to be called by related classes causing static ctor to load types
+        /// </summary>
+        public static void LoadSqlServerTypes() {}
+        
         /// <summary>
         /// Always <code>true</code>. Both queries and client-side conversion will always attempt to repair invalid spatial objects 
         /// </summary>

--- a/SharpMap.SqlServerSpatialObjects/Geometries/SpatialOperationsEx.cs
+++ b/SharpMap.SqlServerSpatialObjects/Geometries/SpatialOperationsEx.cs
@@ -3,7 +3,7 @@
 /*
  *  The attached / following is part of SharpMap.SqlServerSpatialObjects.
  *  
- *  SharpMap.SqlServerSpatialObjects is free software © 2010 Ingenieurgruppe IVV GmbH & Co. KG, 
+ *  SharpMap.SqlServerSpatialObjects is free software ï¿½ 2010 Ingenieurgruppe IVV GmbH & Co. KG, 
  *  www.ivv-aachen.de; you can redistribute it and/or modify it under the terms 
  *  of the current GNU Lesser General Public License (LGPL) as published by and 
  *  available from the Free Software Foundation, Inc., 
@@ -31,6 +31,11 @@ namespace SharpMap.Geometries
     /// </summary>
     public static class SpatialOperationsEx
     {
+        static SpatialOperationsEx()
+        {
+            SqlServer2008Ex.LoadSqlServerTypes();
+        }
+        
         [Obsolete]
         public static Geometry Buffer(Geometry g, Double distance)
         {

--- a/SharpMap.SqlServerSpatialObjects/Geometries/SpatialRelationsEx.cs
+++ b/SharpMap.SqlServerSpatialObjects/Geometries/SpatialRelationsEx.cs
@@ -29,6 +29,11 @@ namespace SharpMap.Geometries
     /// </summary>
     public static class SpatialRelationsEx
     {
+        static SpatialRelationsEx()
+        {
+            SqlServer2008Ex.LoadSqlServerTypes();
+        }
+        
         /// <summary>
         /// Returns true if otherGeometry is wholly contained within the source geometry. This is the same as
         /// reversing the primary and comparison shapes of the Within operation.

--- a/SharpMap.SqlServerSpatialObjects/ReadMe.txt
+++ b/SharpMap.SqlServerSpatialObjects/ReadMe.txt
@@ -1,4 +1,29 @@
-﻿In order to use this project you need to add a reference to the
+﻿Update Sep 2019: Resolve SqlServer dependencies and loading native types
+
+1) SqlServer dependencies (x32 and x64) now defined by NuGet package Microsoft.SqlServer.Types
+    This includes:
+        Microsoft.SqlServer.Types.dll
+        msvcr120.dll            (x32/x64)
+        SqlServerSpatial140.dll (x32/x64)
+2) Loading x32 or x64 native types at runtime now handled internally by static constructors
+3) Your project should only reference SharpMap.SqlServerSpatialObjects:
+    a) Your project does NOT need NuGet package Microsoft.SqlServer.Types
+    b) Your project does NOT need to explicitly load SqlServer types at runtime
+    c) Your project most likely requires a BINDING REDIRECT (see WinformSamples app.config)
+        </runtime>
+            </assemblyBinding>
+                <dependentAssembly>
+                    <assemblyIdentity name="Microsoft.SqlServer.Types" publicKeyToken="89845dcd8080cc91" culture="neutral" />
+                    <bindingRedirect oldVersion="10.0.0.0-15.0.0.0" newVersion="14.0.0.0" />
+                </dependentAssembly>
+            </assemblyBinding>
+         </runtime>
+    d) If you remove NuGet package Microsoft.SqlServer.Types from your project, you will probably need manually delete 
+       sub-folder "SqlServerTypes". Otherwise, SqlServer dependencies may not be copied across during build.  
+
+=================================================================================================================================
+
+In order to use this project you need to add a reference to the
 "Microsoft SQL Server System CLR Types". 
 
 If you have SqlServer2008 (Express) installed on your machine you'll probably find in somewhere 
@@ -27,7 +52,7 @@ Several more recents approaches were also considered, but would have caused brea
    This package support x86 and x64, and also includes SqlServerSpatialxxx.dll (no need to install any other Sql Server binaries).
    Also requires binding redirects, and native SQL assemblies must be explicitly loaded at runtime by client (breaking change)
 2) Use NuGet NetTopologySuite.Io.SqlServerBytes (released Oct 2018) instead of SqlGeometryConverter.cs
-   This package provides comprehenisve conversion between NTS geometry and SQL Server geometery/geography types, but targets NetStandard 2.0.
+   This package provides comprehensive conversion between NTS geometry and SQL Server geometery/geography types, but targets NetStandard 2.0.
    Also, SqlGeometryConverter.cs implements custom exception handling.
 
 Regards

--- a/SharpMap.SqlServerSpatialObjects/SharpMap.SqlServerSpatialObjects.csproj
+++ b/SharpMap.SqlServerSpatialObjects/SharpMap.SqlServerSpatialObjects.csproj
@@ -49,9 +49,8 @@
     <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
       <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net40-client\GeoAPI.CoordinateSystems.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Programme\Microsoft SQL Server\100\SDK\Assemblies\Microsoft.SqlServer.Types.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SqlServer.Types.14.0.1016.290\lib\net40\Microsoft.SqlServer.Types.dll</HintPath>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.15.1.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
       <HintPath>..\packages\NetTopologySuite.Core.1.15.1\lib\net40-client\NetTopologySuite.dll</HintPath>
@@ -74,9 +73,23 @@
     <Compile Include="..\SharedAssemblyVersion.cs">
       <Link>Properties\SharedAssemblyVersion.cs</Link>
     </Compile>
+    <Compile Include="SqlServerTypes\Loader.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ReadMe.txt" />
+    <Content Include="SqlServerTypes\readme.htm" />
+    <Content Include="SqlServerTypes\x64\msvcr120.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SqlServerTypes\x64\SqlServerSpatial140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SqlServerTypes\x86\msvcr120.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SqlServerTypes\x86\SqlServerSpatial140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/SharpMap.SqlServerSpatialObjects/packages.config
+++ b/SharpMap.SqlServerSpatialObjects/packages.config
@@ -5,6 +5,7 @@
   <package id="GeoAPI" version="1.7.5" targetFramework="net40-client" />
   <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net40-client" />
   <package id="GeoAPI.Core" version="1.7.5" targetFramework="net40-client" />
+  <package id="Microsoft.SqlServer.Types" version="14.0.1016.290" targetFramework="net40-client" />
   <package id="NetTopologySuite" version="1.15.1" targetFramework="net40-client" />
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.1" targetFramework="net40-client" />
   <package id="NetTopologySuite.Core" version="1.15.1" targetFramework="net40-client" />

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -60,13 +60,10 @@
   </Target>
   -->
   <ItemGroup Condition=" '$(Configuration)' != 'ReleaseLinux' ">
-    <!--<Reference Include="Microsoft.SqlServer.Types, Version=13.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />-->
-    <Reference Include="Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Programme\Microsoft SQL Server\100\SDK\Assemblies\Microsoft.SqlServer.Types.dll</HintPath>
-    </Reference>
+      <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+          <HintPath>..\packages\Microsoft.SqlServer.Types.14.0.1016.290\lib\net40\Microsoft.SqlServer.Types.dll</HintPath>
+      </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="BruTile, Version=0.18.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\BruTile.0.18.1\lib\net40\BruTile.dll</HintPath>


### PR DESCRIPTION
PR to resolve Issue #140 by simplifying dependencies when working with SqlServer spatial types (ie geometry and geography). **SharpMap.SqlServerSpatialObjects** now references NuGet package Microsoft.SqlServer.Types (referred to below as "_the Nuget Package_") and resolves loading x32 or x64 SqlServer binaries at runtime via static constructors. Also, there is no longer any requirement to install SqlServer binaries to get a reference to `Microsoft.SqlServer.Types.dll` as this is part of _the NuGet package_.

Additional notes are provided in [readme.txt](https://github.com/SharpMap/SharpMap/commit/4977f04db16b2a9572ae5a63a177e9ccb869f6a5#diff-b34593258a3d704f4ee9391ccc85c770) including defining Binding Redirect for `Microsoft.SqlServer.Types.dll`, and possible house-keeping in project when removing _the NuGet package_. `WinformSamples` has been updated to show how to use SqlServer spatial types without _the NuGet package_.

Existing SqlServer tests in UnitTests have been validated. The Converter tests require reference `Microsoft.SqlServer.Types.dll` - note hint to package path (ie UnitTests does not need to add _the Nuget package_). 