### PR TITLE
Updated WinForm WMS example

### DIFF
--- a/Examples/WinFormSamples/Samples/WmsSample.cs
+++ b/Examples/WinFormSamples/Samples/WmsSample.cs
@@ -17,7 +17,7 @@ namespace WinFormSamples.Samples
 
             WmsLayer layWms = new WmsLayer("Brunnar", wmsUrl);
 
-            layWms.AddLayer("grundvatten:SE.GOV.SGU.BRUNNAR.250K");
+            layWms.AddLayer("SE.GOV.SGU.BRUNNAR.250K");
             //layWms.AddLayer("Topography");
             //layWms.AddLayer("Hillshading");
 
@@ -27,7 +27,8 @@ namespace WinFormSamples.Samples
             layWms.TimeOut = 20000; //Set timeout to 5 seconds
             layWms.SRID = 3006;
 
-            map.BackgroundLayer.Add(AsyncLayerProxyLayer.Create(layWms, new Size(256, 256)));
+            //map.BackgroundLayer.Add(AsyncLayerProxyLayer.Create(layWms, new Size(256, 256)));
+            map.BackgroundLayer.Add(layWms);
             map.MaximumExtents = layWms.Envelope;
             
             //limit the zoom to 360 degrees width

--- a/SharpMap/Layers/WmsLayer.cs
+++ b/SharpMap/Layers/WmsLayer.cs
@@ -421,7 +421,7 @@ namespace SharpMap.Layers
         /// </summary>
         /// <remarks>Layer names are case sensitive.</remarks>
         /// <param name="name">Name of layer</param>
-        /// <exception cref="System.ArgumentException">Throws an exception is an unknown layer is added</exception>
+        /// <exception cref="System.ArgumentException">Throws an exception if an unknown layer is added</exception>
         public void AddLayer(string name)
         {
             if (!LayerExists(_wmsClient.Layer, name))


### PR DESCRIPTION
* updated layername
* changed the tiling of the wms layer to the standard

When adding the layer through the AsyncLayerProxyLayer tiles of the map are a bit mixed, but when using the standard method it is working. (Compared with the rendering on QGIS)
